### PR TITLE
Add *.mocks.dart to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.logger.dart
 *.g.dart
 *.freezed.dart
+*.mocks.dart
 *.lock
 pubspec.lock
 # Web related


### PR DESCRIPTION
Much like *.g.dart and *.freezed.dart, I do not think that *.mocks.dart files need to be synced since they will be generated like those other files.