### PR TITLE
Correct Y Axis Drawing Below 0c

### DIFF
--- a/lib/ui/components/graph_card_with_button.dart
+++ b/lib/ui/components/graph_card_with_button.dart
@@ -137,6 +137,8 @@ class _Chart extends StatelessWidget {
             belowBarData: BarAreaData(
               show: true,
               color: graphColor,
+              applyCutOffY: true,
+              cutOffY: 0,
             ),
           ),
         ],


### PR DESCRIPTION
This commit corrects issue #101 and will prevent the graph from drawing its area under the card. This will still slope the line to correspond with the negative values.