### PR TITLE
Prevent Graph Card from Drawing -Y Values

### DIFF
--- a/lib/ui/components/graph_card_with_button.dart
+++ b/lib/ui/components/graph_card_with_button.dart
@@ -137,6 +137,8 @@ class _Chart extends StatelessWidget {
             belowBarData: BarAreaData(
               show: true,
               color: graphColor,
+              applyCutOffY: true,
+              cutOffY: 0,
             ),
           ),
         ],

--- a/lib/ui/screens/dashboard/tabs/general_tab.dart
+++ b/lib/ui/screens/dashboard/tabs/general_tab.dart
@@ -472,8 +472,7 @@ class _ExtruderCard extends HookConsumerWidget {
           temperatureHistory.sublist(max(0, temperatureHistory.length - 300));
 
       spots.value.clear();
-      spots.value
-          .addAll(sublist.mapIndex((e, i) => FlSpot(max(i.toDouble(), 0), e)));
+      spots.value.addAll(sublist.mapIndex((e, i) => FlSpot(i.toDouble(), e)));
     }
     final String extruderNameStr =
         tr('pages.dashboard.control.extrude_card.title');
@@ -508,8 +507,7 @@ class _HeatedBedCard extends HookConsumerWidget {
       List<double> sublist =
           temperatureHistory.sublist(max(0, temperatureHistory.length - 300));
       spots.value.clear();
-      spots.value
-          .addAll(sublist.mapIndex((e, i) => FlSpot(max(i.toDouble(), 0), e)));
+      spots.value.addAll(sublist.mapIndex((e, i) => FlSpot(i.toDouble(), e)));
     }
 
     return _HeaterCard(
@@ -541,8 +539,7 @@ class _SensorCard extends HookConsumerWidget {
       List<double> sublist =
           temperatureHistory.sublist(max(0, temperatureHistory.length - 300));
       spots.value.clear();
-      spots.value
-          .addAll(sublist.mapIndex((e, i) => FlSpot(max(i.toDouble(), 0), e)));
+      spots.value.addAll(sublist.mapIndex((e, i) => FlSpot(i.toDouble(), e)));
     }
     var beautifiedNamed = beautifyName(temperatureSensor.name);
 


### PR DESCRIPTION
Alternate solution to #101 that will slope the line as intended but prevent the graph from drawing negative Y axis values. This also removes the need to modify the temperature values in multiple locations. Prior Master branch PR was removed.