### PR TITLE
Remove requirement for TLD on printer address

### DIFF
--- a/lib/ui/screens/printers/edit/printers_edit_page.dart
+++ b/lib/ui/screens/printers/edit/printers_edit_page.dart
@@ -123,7 +123,7 @@ class PrinterSettingScrollView extends ConsumerWidget {
                 validator: FormBuilderValidators.compose([
                   FormBuilderValidators.required(),
                   FormBuilderValidators.url(
-                      protocols: ['http', 'https'], requireProtocol: true)
+                      protocols: ['http', 'https'], requireProtocol: true, requireTld: false)
                 ]),
               ),
               FormBuilderTextField(


### PR DESCRIPTION
When adding or changing a printer, the address field is considered invalid if only a protocol and a hostname are entered; for instance, `http://printer` is invalid input to the address field.

This changes the validator on the field and allows the absence of a top-level domain.