### PR TITLE
Use JsonSerializable fromJson to update objects

### DIFF
--- a/lib/data/converters/pixel_converter.dart
+++ b/lib/data/converters/pixel_converter.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mobileraker/data/dto/machine/leds/led.dart';
+
+class PixelConverter extends JsonConverter<Pixel, List<dynamic>> {
+  const PixelConverter();
+
+  @override
+  Pixel fromJson(List<dynamic> json) {
+    if (json.isEmpty) return const Pixel();
+
+    var list = json.map((e) => (e as num).toDouble()).toList();
+    return Pixel.fromList(list);
+  }
+
+  @override
+  List<dynamic> toJson(Pixel object) => object.asList().toList(growable: false);
+}

--- a/lib/data/converters/vector2_converter.dart
+++ b/lib/data/converters/vector2_converter.dart
@@ -1,0 +1,21 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:vector_math/vector_math.dart';
+
+class Vector2Converter extends JsonConverter<Vector2, List<dynamic>> {
+  const Vector2Converter();
+
+  @override
+  Vector2 fromJson(List<dynamic> json) {
+    if (json.isEmpty) return Vector2.zero();
+
+    var list = json.map((e) => (e as num).toDouble()).toList();
+    return Vector2.array(list);
+  }
+
+  @override
+  List<dynamic> toJson(Vector2 object) {
+    var list = <double>[0, 0];
+    object.copyIntoArray(list);
+    return list.toList(growable: false);
+  }
+}

--- a/lib/data/dto/machine/display_status.dart
+++ b/lib/data/dto/machine/display_status.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'display_status.freezed.dart';
-
+part 'display_status.g.dart';
 
 @freezed
 class DisplayStatus with _$DisplayStatus {
@@ -9,4 +9,14 @@ class DisplayStatus with _$DisplayStatus {
     @Default(0) double progress,
     String? message,
   }) = _DisplayStatus;
+
+  factory DisplayStatus.fromJson(Map<String, dynamic> json) =>
+      _$DisplayStatusFromJson(json);
+
+  factory DisplayStatus.partialUpdate(
+      DisplayStatus? current, Map<String, dynamic> partialJson) {
+    DisplayStatus old = current ?? const DisplayStatus();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return DisplayStatus.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/exclude_object.dart
+++ b/lib/data/dto/machine/exclude_object.dart
@@ -1,17 +1,33 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/data/converters/vector2_converter.dart';
 import 'package:vector_math/vector_math.dart';
 
 part 'exclude_object.freezed.dart';
+part 'exclude_object.g.dart';
 
 @freezed
 class ExcludeObject with _$ExcludeObject {
   const ExcludeObject._();
 
+  @JsonSerializable(explicitToJson: true)
   const factory ExcludeObject({
-    String? currentObject,
-    @Default([]) List<String> excludedObjects,
-    @Default([]) List<ParsedObject> objects,
+    @JsonKey(name: 'current_object') String? currentObject,
+    @JsonKey(name: 'excluded_objects')
+    @Default([])
+        List<String> excludedObjects,
+    @JsonKey() @Default([]) List<ParsedObject> objects,
   }) = _ExcludeObject;
+
+  factory ExcludeObject.fromJson(Map<String, dynamic> json) =>
+      _$ExcludeObjectFromJson(json);
+
+  factory ExcludeObject.partialUpdate(
+      ExcludeObject? current, Map<String, dynamic> partialJson) {
+    ExcludeObject old = current ?? const ExcludeObject();
+    var mergedJson = {...old.toJson(), ...partialJson};
+
+    return ExcludeObject.fromJson(mergedJson);
+  }
 
   bool get available => objects.isNotEmpty;
 
@@ -24,7 +40,13 @@ class ExcludeObject with _$ExcludeObject {
 class ParsedObject with _$ParsedObject {
   const factory ParsedObject({
     required String name,
-    required Vector2 center,
-    @Default([]) List<Vector2> polygons,
+    @Vector2Converter() required Vector2 center,
+    @Vector2Converter()
+    @JsonKey(name: 'polygon')
+    @Default([])
+        List<Vector2> polygons,
   }) = _ParsedObject;
+
+  factory ParsedObject.fromJson(Map<String, dynamic> json) =>
+      _$ParsedObjectFromJson(json);
 }

--- a/lib/data/dto/machine/extruder.dart
+++ b/lib/data/dto/machine/extruder.dart
@@ -1,6 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/util/json_util.dart';
 
 part 'extruder.freezed.dart';
+part 'extruder.g.dart';
 
 @freezed
 class Extruder with _$Extruder {
@@ -8,15 +10,39 @@ class Extruder with _$Extruder {
     return Extruder(num: num, lastHistory: DateTime(1990));
   }
 
-  const factory Extruder(
-      {required int num,
-      @Default(0) double temperature,
-      @Default(0) double target,
-      @Default(0) double pressureAdvance,
-      @Default(0) double smoothTime,
-      @Default(0) double power,
-      List<double>? temperatureHistory,
-      List<double>? targetHistory,
-      List<double>? powerHistory,
-      required DateTime lastHistory}) = _Extruder;
+  const factory Extruder({required int num,
+    @Default(0) double temperature,
+    @Default(0) double target,
+    @JsonKey(name: 'pressure_advance') @Default(0) double pressureAdvance,
+    @JsonKey(name: 'smooth_time') @Default(0) double smoothTime,
+    @Default(0) double power,
+    @JsonKey(name: 'temperatures') List<double>? temperatureHistory,
+    @JsonKey(name: 'targets') List<double>? targetHistory,
+    @JsonKey(name: 'powers') List<double>? powerHistory,
+    required DateTime lastHistory}) = _Extruder;
+
+  factory Extruder.fromJson(Map<String, dynamic> json) =>
+      _$ExtruderFromJson(json);
+
+  factory Extruder.partialUpdate(Extruder current,
+      Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    // Ill just put the tempCache here because I am lazy.. kinda sucks but who cares
+    // Update temp cache for graphs!
+    DateTime now = DateTime.now();
+    if (now
+        .difference(current.lastHistory)
+        .inSeconds >= 1) {
+      mergedJson = {
+        ...mergedJson,
+        'temperatures':
+        updateHistoryListInJson(mergedJson, 'temperatures', 'temperature'),
+        'targets': updateHistoryListInJson(mergedJson, 'targets', 'target'),
+        'powers': updateHistoryListInJson(mergedJson, 'powers', 'power'),
+        'lastHistory': now.toIso8601String()
+      };
+    }
+
+    return Extruder.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/fans/controller_fan.dart
+++ b/lib/data/dto/machine/fans/controller_fan.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'named_fan.dart';
 
 part 'controller_fan.freezed.dart';
+part 'controller_fan.g.dart';
 
 @freezed
 class ControllerFan extends NamedFan with _$ControllerFan {
@@ -10,4 +11,13 @@ class ControllerFan extends NamedFan with _$ControllerFan {
     required String name,
     @Default(0) double speed,
   }) = _ControllerFan;
+
+  factory ControllerFan.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$ControllerFanFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory ControllerFan.partialUpdate(
+      ControllerFan current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return ControllerFan.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/fans/generic_fan.dart
+++ b/lib/data/dto/machine/fans/generic_fan.dart
@@ -2,8 +2,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'named_fan.dart';
 
-
 part 'generic_fan.freezed.dart';
+part 'generic_fan.g.dart';
 
 @freezed
 class GenericFan extends NamedFan with _$GenericFan {
@@ -11,4 +11,13 @@ class GenericFan extends NamedFan with _$GenericFan {
     required String name,
     @Default(0) double speed,
   }) = _GenericFan;
+
+  factory GenericFan.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$GenericFanFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory GenericFan.partialUpdate(
+      GenericFan current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return GenericFan.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/fans/heater_fan.dart
+++ b/lib/data/dto/machine/fans/heater_fan.dart
@@ -2,8 +2,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'named_fan.dart';
 
-
 part 'heater_fan.freezed.dart';
+part 'heater_fan.g.dart';
 
 @freezed
 class HeaterFan extends NamedFan with _$HeaterFan {
@@ -11,4 +11,13 @@ class HeaterFan extends NamedFan with _$HeaterFan {
     required String name,
     @Default(0) double speed,
   }) = _HeaterFan;
+
+  factory HeaterFan.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$HeaterFanFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory HeaterFan.partialUpdate(
+      HeaterFan current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return HeaterFan.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/fans/print_fan.dart
+++ b/lib/data/dto/machine/fans/print_fan.dart
@@ -1,22 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
 import 'fan.dart';
 
-class PrintFan implements Fan {
-  const PrintFan({this.speed = 0.0});
+part 'print_fan.freezed.dart';
+part 'print_fan.g.dart';
 
-  @override
-  final double speed;
+@freezed
+class PrintFan with _$PrintFan implements Fan {
+  const factory PrintFan({
+    @Default(0) double speed,
+  }) = _PrintFan;
 
-  PrintFan copyWith({double? speed}) {
-    return PrintFan(speed: speed ?? this.speed);
+  factory PrintFan.fromJson(Map<String, dynamic> json) =>
+      _$PrintFanFromJson(json);
+
+  factory PrintFan.partialUpdate(
+      PrintFan? current, Map<String, dynamic> partialJson) {
+    PrintFan old = current ?? const PrintFan();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return PrintFan.fromJson(mergedJson);
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is PrintFan &&
-          runtimeType == other.runtimeType &&
-          speed == other.speed;
-
-  @override
-  int get hashCode => speed.hashCode;
 }

--- a/lib/data/dto/machine/fans/temperature_fan.dart
+++ b/lib/data/dto/machine/fans/temperature_fan.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'named_fan.dart';
 
 part 'temperature_fan.freezed.dart';
+part 'temperature_fan.g.dart';
 
 //     "temperature_fan Case": {
 // "speed": 0,
@@ -15,15 +16,23 @@ part 'temperature_fan.freezed.dart';
 class TemperatureFan extends NamedFan with _$TemperatureFan {
   const TemperatureFan._();
 
-  const factory TemperatureFan({
-    required String name,
-    @Default(0) double speed,
-    double? rpm,
-    @Default(0) double temperature,
-    @Default(0) double target,
-    List<double>? temperatureHistory,
-    List<double>? targetHistory,
-    List<double>? powerHistory,
-    required DateTime lastHistory
-  }) = _TemperatureFan;
+  const factory TemperatureFan(
+      {required String name,
+      @Default(0) double speed,
+      double? rpm,
+      @Default(0) double temperature,
+      @Default(0) double target,
+      @JsonKey(name: 'temperatures') List<double>? temperatureHistory,
+      @JsonKey(name: 'targets') List<double>? targetHistory,
+      @JsonKey(name: 'powers') List<double>? powerHistory,
+      required DateTime lastHistory}) = _TemperatureFan;
+
+  factory TemperatureFan.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$TemperatureFanFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory TemperatureFan.partialUpdate(
+      TemperatureFan current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return TemperatureFan.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/gcode_move.dart
+++ b/lib/data/dto/machine/gcode_move.dart
@@ -1,23 +1,47 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/util/extensions/double_extension.dart';
 
 part 'gcode_move.freezed.dart';
+part 'gcode_move.g.dart';
 
 @freezed
 class GCodeMove with _$GCodeMove {
   const GCodeMove._();
 
   const factory GCodeMove({
-    @Default(0) double speedFactor,
+    @JsonKey(name: 'speed_factor', fromJson: _toTwoFractions)
+    @Default(0)
+        double speedFactor,
     @Default(0) double speed,
-    @Default(0) double extrudeFactor,
-    @Default(false) bool absoluteCoordinates,
-    @Default(false) bool absoluteExtrude,
-    @Default([0.0, 0.0, 0.0, 0.0]) List<double> homingOrigin,
+    @JsonKey(name: 'extrude_factor', fromJson: _toTwoFractions)
+    @Default(0)
+        double extrudeFactor,
+    @JsonKey(name: 'absolute_coordinates')
+    @Default(false)
+        bool absoluteCoordinates,
+    @JsonKey(name: 'absolute_extrude') @Default(false) bool absoluteExtrude,
+    @JsonKey(name: 'homing_origin')
+    @Default([0.0, 0.0, 0.0, 0.0])
+        List<double> homingOrigin,
     @Default([0.0, 0.0, 0.0, 0.0]) List<double> position,
-    @Default([0.0, 0.0, 0.0, 0.0]) List<double> gcodePosition,
+    @JsonKey(name: 'gcode_position')
+    @Default([0.0, 0.0, 0.0, 0.0])
+        List<double> gcodePosition,
   }) = _GCodeMove;
+
+  factory GCodeMove.fromJson(Map<String, dynamic> json) =>
+      _$GCodeMoveFromJson(json);
+
+  factory GCodeMove.partialUpdate(
+      GCodeMove? current, Map<String, dynamic> partialJson) {
+    GCodeMove old = current ?? const GCodeMove();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return GCodeMove.fromJson(mergedJson);
+  }
 
   int get mmSpeed {
     return (speed / 60 * speedFactor).round();
   }
 }
+
+double _toTwoFractions(double d) => d.toPrecision(2);

--- a/lib/data/dto/machine/heater_bed.dart
+++ b/lib/data/dto/machine/heater_bed.dart
@@ -10,9 +10,9 @@ class HeaterBed with _$HeaterBed {
     @Default(0) double temperature,
     @Default(0) double target,
     @Default(0) double power,
-    List<double>? temperatureHistory,
-    List<double>? targetHistory,
-    List<double>? powerHistory,
+    @JsonKey(name: 'temperatures') List<double>? temperatureHistory,
+    @JsonKey(name: 'targets') List<double>? targetHistory,
+    @JsonKey(name: 'powers') List<double>? powerHistory,
     required DateTime lastHistory,
   }) = _HeaterBed;
 

--- a/lib/data/dto/machine/heater_bed.dart
+++ b/lib/data/dto/machine/heater_bed.dart
@@ -1,6 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/util/json_util.dart';
 
 part 'heater_bed.freezed.dart';
+part 'heater_bed.g.dart';
 
 @freezed
 class HeaterBed with _$HeaterBed {
@@ -13,4 +15,29 @@ class HeaterBed with _$HeaterBed {
     List<double>? powerHistory,
     required DateTime lastHistory,
   }) = _HeaterBed;
+
+  factory HeaterBed.fromJson(Map<String, dynamic> json) =>
+      _$HeaterBedFromJson(json);
+
+  factory HeaterBed.partialUpdate(
+      HeaterBed? current, Map<String, dynamic> partialJson) {
+    HeaterBed old = current ?? HeaterBed(lastHistory: DateTime(1990));
+
+    var mergedJson = {...old.toJson(), ...partialJson};
+    // Ill just put the tempCache here because I am lazy.. kinda sucks but who cares
+    // Update temp cache for graphs!
+    DateTime now = DateTime.now();
+    if (now.difference(old.lastHistory).inSeconds >= 1) {
+      mergedJson = {
+        ...mergedJson,
+        'temperatures':
+            updateHistoryListInJson(mergedJson, 'temperatures', 'temperature'),
+        'targets': updateHistoryListInJson(mergedJson, 'targets', 'target'),
+        'powers': updateHistoryListInJson(mergedJson, 'powers', 'power'),
+        'lastHistory': now.toIso8601String()
+      };
+    }
+
+    return HeaterBed.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/leds/addressable_led.dart
+++ b/lib/data/dto/machine/leds/addressable_led.dart
@@ -1,12 +1,26 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/data/converters/pixel_converter.dart';
 import 'package:mobileraker/data/dto/machine/leds/led.dart';
 
 part 'addressable_led.freezed.dart';
+part 'addressable_led.g.dart';
 
 @freezed
 class AddressableLed extends Led with _$AddressableLed {
   const factory AddressableLed({
     required String name,
-    @Default([]) List<Pixel> pixels,
+    @PixelConverter()
+    @JsonKey(name: 'color_data')
+    @Default([])
+        List<Pixel> pixels,
   }) = _AddressableLed;
+
+  factory AddressableLed.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$AddressableLedFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory AddressableLed.partialUpdate(
+      AddressableLed current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return AddressableLed.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/leds/dumb_led.dart
+++ b/lib/data/dto/machine/leds/dumb_led.dart
@@ -1,12 +1,30 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/data/converters/pixel_converter.dart';
 import 'package:mobileraker/data/dto/machine/leds/led.dart';
 
 part 'dumb_led.freezed.dart';
+part 'dumb_led.g.dart';
 
 @freezed
 class DumbLed extends Led with _$DumbLed {
   const factory DumbLed({
     required String name,
-    @Default(Pixel()) Pixel color,
+    @PixelConverter()
+    @JsonKey(name: 'color_data', readValue: _extractFistLed)
+    @Default(Pixel())
+        Pixel color,
   }) = _DumbLed;
+
+  factory DumbLed.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$DumbLedFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory DumbLed.partialUpdate(
+      DumbLed current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return DumbLed.fromJson(mergedJson);
+  }
+}
+
+Object? _extractFistLed(Map json, String key) {
+  return json[key][0];
 }

--- a/lib/data/dto/machine/leds/led.dart
+++ b/lib/data/dto/machine/leds/led.dart
@@ -1,4 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/data/dto/machine/leds/addressable_led.dart';
+import 'package:mobileraker/data/dto/machine/leds/dumb_led.dart';
 
 part 'led.freezed.dart';
 
@@ -23,5 +25,17 @@ class Pixel with _$Pixel {
 }
 
 abstract class Led {
+  const Led();
+
   abstract final String name;
+
+  factory Led.partialUpdate(Led current, Map<String, dynamic> partialJson) {
+    if (current is DumbLed) {
+      return DumbLed.partialUpdate(current, partialJson);
+    } else if (current is AddressableLed) {
+      return AddressableLed.partialUpdate(current, partialJson);
+    } else {
+      throw UnsupportedError('The provided LED Type is not implemented yet!');
+    }
+  }
 }

--- a/lib/data/dto/machine/motion_report.dart
+++ b/lib/data/dto/machine/motion_report.dart
@@ -1,13 +1,27 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'motion_report.freezed.dart';
-
+part 'motion_report.g.dart';
 
 @freezed
 class MotionReport with _$MotionReport {
   const factory MotionReport({
-    @Default([0.0, 0.0, 0.0, 0.0]) List<double> livePosition,
-    @Default(0) double liveVelocity,
-    @Default(0) double liveExtruderVelocity,
+    @JsonKey(name: 'live_position')
+    @Default([0.0, 0.0, 0.0, 0.0])
+        List<double> livePosition,
+    @JsonKey(name: 'live_velocity') @Default(0) double liveVelocity,
+    @JsonKey(name: 'live_extruder_velocity')
+    @Default(0)
+        double liveExtruderVelocity,
   }) = _MotionReport;
+
+  factory MotionReport.fromJson(Map<String, dynamic> json) =>
+      _$MotionReportFromJson(json);
+
+  factory MotionReport.partialUpdate(
+      MotionReport? current, Map<String, dynamic> partialJson) {
+    MotionReport old = current ?? const MotionReport();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return MotionReport.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/output_pin.dart
+++ b/lib/data/dto/machine/output_pin.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'output_pin.freezed.dart';
+part 'output_pin.g.dart';
 
 @freezed
 class OutputPin with _$OutputPin {
@@ -8,4 +9,13 @@ class OutputPin with _$OutputPin {
     required String name,
     @Default(0.0) double value,
   }) = _OutputPin;
+
+  factory OutputPin.fromJson(Map<String, dynamic> json, [String? name]) =>
+      _$OutputPinFromJson(name != null ? {...json, 'name': name} : json);
+
+  factory OutputPin.partialUpdate(
+      OutputPin current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+    return OutputPin.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/print_stats.dart
+++ b/lib/data/dto/machine/print_stats.dart
@@ -1,7 +1,9 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'print_stats.freezed.dart';
+part 'print_stats.g.dart';
 
+@JsonEnum()
 enum PrintState {
   standby('Standby'),
   printing('Printing'),
@@ -14,19 +16,28 @@ enum PrintState {
   final String displayName;
 }
 
-
 @freezed
 class PrintStats with _$PrintStats {
   const PrintStats._();
 
   const factory PrintStats({
     @Default(PrintState.error) PrintState state,
-    @Default(0) double totalDuration,
-    @Default(0) double printDuration,
-    @Default(0) double filamentUsed,
+    @JsonKey(name: 'total_duration') @Default(0) double totalDuration,
+    @JsonKey(name: 'print_duration') @Default(0) double printDuration,
+    @JsonKey(name: 'filament_used') @Default(0) double filamentUsed,
     @Default('') String message,
     @Default('') String filename,
   }) = _PrintStats;
+
+  factory PrintStats.fromJson(Map<String, dynamic> json) =>
+      _$PrintStatsFromJson(json);
+
+  factory PrintStats.partialUpdate(
+      PrintStats? current, Map<String, dynamic> partialJson) {
+    PrintStats old = current ?? const PrintStats();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return PrintStats.fromJson(mergedJson);
+  }
 
   String get stateName => state.displayName;
 }

--- a/lib/data/dto/machine/temperature_sensor.dart
+++ b/lib/data/dto/machine/temperature_sensor.dart
@@ -1,15 +1,39 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mobileraker/util/json_util.dart';
 
 part 'temperature_sensor.freezed.dart';
+part 'temperature_sensor.g.dart';
 
 @freezed
 class TemperatureSensor with _$TemperatureSensor {
-  const factory TemperatureSensor(
-      {required String name,
-      @Default(0.0) double temperature,
-      @Default(0.0) double measuredMinTemp,
-      @Default(0.0) double measuredMaxTemp,
-      required DateTime lastHistory,
-      List<double>? temperatureHistory,
-      }) = _TemperatureSensor;
+  const factory TemperatureSensor({
+    required String name,
+    @Default(0.0) double temperature,
+    @JsonKey(name: 'measured_min_temp') @Default(0.0) double measuredMinTemp,
+    @JsonKey(name: 'measured_max_temp') @Default(0.0) double measuredMaxTemp,
+    @JsonKey(name: 'temperatures') List<double>? temperatureHistory,
+    required DateTime lastHistory,
+  }) = _TemperatureSensor;
+
+  factory TemperatureSensor.fromJson(Map<String, dynamic> json,
+          [String? name]) =>
+      _$TemperatureSensorFromJson(
+          name != null ? {...json, 'name': name} : json);
+
+  factory TemperatureSensor.partialUpdate(
+      TemperatureSensor current, Map<String, dynamic> partialJson) {
+    var mergedJson = {...current.toJson(), ...partialJson};
+
+    DateTime now = DateTime.now();
+    if (now.difference(current.lastHistory).inSeconds >= 1) {
+      mergedJson = {
+        ...mergedJson,
+        'temperatures':
+            updateHistoryListInJson(mergedJson, 'temperatures', 'temperature'),
+        'lastHistory': now.toIso8601String()
+      };
+    }
+
+    return TemperatureSensor.fromJson(mergedJson);
+  }
 }

--- a/lib/data/dto/machine/toolhead.dart
+++ b/lib/data/dto/machine/toolhead.dart
@@ -47,29 +47,3 @@ class Toolhead with _$Toolhead {
     return Toolhead.fromJson(mergedJson);
   }
 }
-
-//
-//
-// Toolhead toolhead = printer.toolhead ?? const Toolhead();
-//
-// Set<PrinterAxis> homedAxes = toolhead.homedAxes;
-// List<double> position = toolhead.position;
-// double? printTime = toolhead.printTime;
-// double? estimatedPrintTime = toolhead.estimatedPrintTime;
-// double maxVelocity = toolhead.maxVelocity;
-// double maxAccel = toolhead.maxAccel;
-// double maxAccelToDecel = toolhead.maxAccelToDecel;
-// String activeExtruder = toolhead.activeExtruder;
-// double squareCornerVelocity = toolhead.squareCornerVelocity;
-//
-// if (toolHeadJson.containsKey('homed_axes')) {
-// String hAxes = toolHeadJson['homed_axes'];
-// homedAxes = hAxes
-//     .toUpperCase()
-//     .split('')
-//     .map((e) => EnumToString.fromString(PrinterAxis.values, e)!)
-//     .toSet();
-// }
-// if (toolHeadJson.containsKey('extruder')) {
-// activeExtruder = toolHeadJson['extruder'];
-// }

--- a/lib/data/dto/machine/toolhead.dart
+++ b/lib/data/dto/machine/toolhead.dart
@@ -1,20 +1,75 @@
+import 'package:enum_to_string/enum_to_string.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'toolhead.freezed.dart';
+part 'toolhead.g.dart';
 
 enum PrinterAxis { X, Y, Z, E }
+
+Set<PrinterAxis> _homedAxisFromJson(String haxis) => haxis
+    .toUpperCase()
+    .split('')
+    .map((e) => EnumToString.fromString(PrinterAxis.values, e)!)
+    .toSet();
+
+String _homedAxisToJson(Set<PrinterAxis> homed) =>
+    homed.map((e) => e.name).join();
 
 @freezed
 class Toolhead with _$Toolhead {
   const factory Toolhead({
-    @Default(<PrinterAxis>{}) Set<PrinterAxis> homedAxes,
+    @JsonKey(
+        name: 'homed_axes',
+        fromJson: _homedAxisFromJson,
+        toJson: _homedAxisToJson)
+    @Default(<PrinterAxis>{})
+        Set<PrinterAxis> homedAxes,
     @Default([0.0, 0.0, 0.0, 0.0]) List<double> position,
-    @Default('extruder') String activeExtruder,
-    double? printTime,
-    double? estimatedPrintTime,
-    @Default(500) double maxVelocity,
-    @Default(3000) double maxAccel,
-    @Default(3000) double maxAccelToDecel,
-    @Default(1500) double squareCornerVelocity,
+    @JsonKey(name: 'extruder') @Default('extruder') String activeExtruder,
+    @JsonKey(name: 'print_time') double? printTime,
+    @JsonKey(name: 'estimated_print_time') double? estimatedPrintTime,
+    @JsonKey(name: 'max_velocity') @Default(500) double maxVelocity,
+    @JsonKey(name: 'max_accel') @Default(3000) double maxAccel,
+    @JsonKey(name: 'max_accel_to_decel') @Default(3000) double maxAccelToDecel,
+    @JsonKey(name: 'square_corner_velocity')
+    @Default(1500)
+        double squareCornerVelocity,
   }) = _Toolhead;
+
+  factory Toolhead.fromJson(Map<String, dynamic> json) =>
+      _$ToolheadFromJson(json);
+
+  factory Toolhead.partialUpdate(
+      Toolhead? current, Map<String, dynamic> partialJson) {
+    Toolhead old = current ?? const Toolhead();
+    var mergedJson = {...old.toJson(), ...partialJson};
+
+    return Toolhead.fromJson(mergedJson);
+  }
 }
+
+//
+//
+// Toolhead toolhead = printer.toolhead ?? const Toolhead();
+//
+// Set<PrinterAxis> homedAxes = toolhead.homedAxes;
+// List<double> position = toolhead.position;
+// double? printTime = toolhead.printTime;
+// double? estimatedPrintTime = toolhead.estimatedPrintTime;
+// double maxVelocity = toolhead.maxVelocity;
+// double maxAccel = toolhead.maxAccel;
+// double maxAccelToDecel = toolhead.maxAccelToDecel;
+// String activeExtruder = toolhead.activeExtruder;
+// double squareCornerVelocity = toolhead.squareCornerVelocity;
+//
+// if (toolHeadJson.containsKey('homed_axes')) {
+// String hAxes = toolHeadJson['homed_axes'];
+// homedAxes = hAxes
+//     .toUpperCase()
+//     .split('')
+//     .map((e) => EnumToString.fromString(PrinterAxis.values, e)!)
+//     .toSet();
+// }
+// if (toolHeadJson.containsKey('extruder')) {
+// activeExtruder = toolHeadJson['extruder'];
+// }

--- a/lib/data/dto/machine/virtual_sd_card.dart
+++ b/lib/data/dto/machine/virtual_sd_card.dart
@@ -1,12 +1,23 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'virtual_sd_card.freezed.dart';
+part 'virtual_sd_card.g.dart';
 
 @freezed
 class VirtualSdCard with _$VirtualSdCard {
   const factory VirtualSdCard({
     @Default(0) double progress,
-    @Default(false) bool isActive,
-    @Default(0) int filePosition,
+    @JsonKey(name: 'is_active') @Default(false) bool isActive,
+    @JsonKey(name: 'file_position') @Default(0) int filePosition,
   }) = _VirtualSdCard;
+
+  factory VirtualSdCard.fromJson(Map<String, dynamic> json) =>
+      _$VirtualSdCardFromJson(json);
+
+  factory VirtualSdCard.partialUpdate(
+      VirtualSdCard? current, Map<String, dynamic> partialJson) {
+    VirtualSdCard old = current ?? const VirtualSdCard();
+    var mergedJson = {...old.toJson(), ...partialJson};
+    return VirtualSdCard.fromJson(mergedJson);
+  }
 }

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -42,7 +42,6 @@ import 'package:mobileraker/service/ui/snackbar_service.dart';
 import 'package:mobileraker/util/ref_extension.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:stringr/stringr.dart';
-import 'package:vector_math/vector_math.dart';
 
 part 'printer_service.g.dart';
 
@@ -721,58 +720,9 @@ class PrinterService {
 
   _updateExcludeObject(Map<String, dynamic> json,
       {required PrinterBuilder printer}) {
-    String? currentObject;
-    List<String>? excludedObjects;
-    List<ParsedObject>? objects;
-
-    if (json.containsKey('current_object')) {
-      currentObject = json['current_object'];
-    }
-
-    if (json.containsKey('excluded_objects')) {
-      excludedObjects =
-          (json['excluded_objects'] as List<dynamic>).cast<String>();
-    }
-    if (json.containsKey('objects')) {
-      List<dynamic> objRaw = json['objects'];
-      List<ParsedObject> prasedObjects = [];
-      for (Map<String, dynamic> e in objRaw) {
-        Vector2 center;
-        String name = e['name'];
-        List<Vector2> polygons;
-        if (e.containsKey('center')) {
-          List<dynamic> centerFromMsg = e['center'];
-          center = centerFromMsg.isEmpty
-              ? Vector2.zero()
-              : Vector2.array(
-                  centerFromMsg.cast<num>().map((e) => e.toDouble()).toList());
-        } else {
-          center = Vector2.zero();
-        }
-        if (e.containsKey('polygon')) {
-          List<dynamic> polys = e['polygon'];
-          polygons = polys.map((e) {
-            List<dynamic> list = e as List<dynamic>;
-            return Vector2.array(
-                list.cast<num>().map((e) => e.toDouble()).toList());
-          }).toList(growable: false);
-        } else {
-          polygons = [];
-        }
-
-        prasedObjects
-            .add(ParsedObject(name: name, center: center, polygons: polygons));
-      }
-
-      objects = List.unmodifiable(prasedObjects);
-    }
-
-    ExcludeObject old = printer.excludeObject ?? const ExcludeObject();
-    printer.excludeObject = old.copyWith(
-        currentObject: currentObject,
-        excludedObjects: excludedObjects ?? old.excludedObjects,
-        objects: objects ?? old.objects);
-    logger.v('New exclude_printer: ${printer.excludeObject}');
+    printer.excludeObject =
+        ExcludeObject.partialUpdate(printer.excludeObject, json);
+    logger.e('New exclude_printer: ${printer.excludeObject}');
   }
 
   _updateLed(String led, Map<String, dynamic> ledJson,

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -877,59 +877,8 @@ class PrinterService {
 
   _updateHeaterBed(Map<String, dynamic> heatedBedJson,
       {required PrinterBuilder printer}) {
-    HeaterBed old = printer.heaterBed ?? HeaterBed(lastHistory: DateTime(1990));
-
-    double? temperature;
-    double? target;
-    double? power;
-    List<double>? temperatureHistory;
-    List<double>? targetHistory;
-    List<double>? powerHistory;
-    DateTime? lastHistory;
-
-    if (heatedBedJson.containsKey('temperature')) {
-      temperature = heatedBedJson['temperature'];
-    }
-    if (heatedBedJson.containsKey('target')) {
-      target = heatedBedJson['target'];
-    }
-    if (heatedBedJson.containsKey('power')) {
-      power = heatedBedJson['power'];
-    }
-
-    // Update temp cache for graphs!
-    DateTime now = DateTime.now();
-    if (now.difference(old.lastHistory).inSeconds >= 1) {
-      temperatureHistory = _updateHistoryList(
-          old.temperatureHistory, temperature ?? old.temperature);
-      targetHistory =
-          _updateHistoryList(old.targetHistory, target ?? old.target);
-      powerHistory = _updateHistoryList(old.powerHistory, power ?? old.target);
-      lastHistory = now;
-    }
-
-    // Ill just put the tempCache here because I am lazy.. kinda sucks but who cares
-    if (heatedBedJson.containsKey('temperatures')) {
-      temperatureHistory =
-          (heatedBedJson['temperatures'] as List<dynamic>).cast<double>();
-    }
-    if (heatedBedJson.containsKey('targets')) {
-      targetHistory =
-          (heatedBedJson['targets'] as List<dynamic>).cast<double>();
-    }
-    if (heatedBedJson.containsKey('powers')) {
-      powerHistory = (heatedBedJson['powers'] as List<dynamic>).cast<double>();
-    }
-
-    printer.heaterBed = HeaterBed(
-      temperature: temperature ?? old.temperature,
-      target: target ?? old.target,
-      power: power ?? old.power,
-      temperatureHistory: temperatureHistory ?? old.temperatureHistory,
-      targetHistory: targetHistory ?? old.targetHistory,
-      powerHistory: powerHistory ?? old.powerHistory,
-      lastHistory: lastHistory ?? old.lastHistory,
-    );
+    printer.heaterBed =
+        HeaterBed.partialUpdate(printer.heaterBed, heatedBedJson);
   }
 
   _updateExtruder(Map<String, dynamic> extruderJson,
@@ -1003,62 +952,7 @@ class PrinterService {
 
   _updateToolhead(Map<String, dynamic> toolHeadJson,
       {required PrinterBuilder printer}) {
-    Toolhead toolhead = printer.toolhead ?? const Toolhead();
-
-    Set<PrinterAxis> homedAxes = toolhead.homedAxes;
-    List<double> position = toolhead.position;
-    double? printTime = toolhead.printTime;
-    double? estimatedPrintTime = toolhead.estimatedPrintTime;
-    double maxVelocity = toolhead.maxVelocity;
-    double maxAccel = toolhead.maxAccel;
-    double maxAccelToDecel = toolhead.maxAccelToDecel;
-    String activeExtruder = toolhead.activeExtruder;
-    double squareCornerVelocity = toolhead.squareCornerVelocity;
-
-    if (toolHeadJson.containsKey('homed_axes')) {
-      String hAxes = toolHeadJson['homed_axes'];
-      homedAxes = hAxes
-          .toUpperCase()
-          .split('')
-          .map((e) => EnumToString.fromString(PrinterAxis.values, e)!)
-          .toSet();
-    }
-    if (toolHeadJson.containsKey('position')) {
-      position = toolHeadJson['position'].cast<double>();
-    }
-    if (toolHeadJson.containsKey('print_time')) {
-      printTime = toolHeadJson['print_time'];
-    }
-    if (toolHeadJson.containsKey('max_velocity')) {
-      maxVelocity = toolHeadJson['max_velocity'];
-    }
-    if (toolHeadJson.containsKey('max_accel')) {
-      maxAccel = toolHeadJson['max_accel'];
-    }
-    if (toolHeadJson.containsKey('max_accel_to_decel')) {
-      maxAccelToDecel = toolHeadJson['max_accel_to_decel'];
-    }
-    if (toolHeadJson.containsKey('extruder')) {
-      activeExtruder = toolHeadJson['extruder'];
-    }
-    if (toolHeadJson.containsKey('square_corner_velocity')) {
-      squareCornerVelocity = toolHeadJson['square_corner_velocity'];
-    }
-    if (toolHeadJson.containsKey('estimated_print_time')) {
-      estimatedPrintTime = toolHeadJson['estimated_print_time'];
-    }
-
-    printer.toolhead = toolhead.copyWith(
-      homedAxes: homedAxes,
-      position: position,
-      printTime: printTime,
-      estimatedPrintTime: estimatedPrintTime,
-      maxVelocity: maxVelocity,
-      maxAccel: maxAccel,
-      maxAccelToDecel: maxAccelToDecel,
-      activeExtruder: activeExtruder,
-      squareCornerVelocity: squareCornerVelocity,
-    );
+    printer.toolhead = Toolhead.partialUpdate(printer.toolhead, toolHeadJson);
   }
 
   _updateExcludeObject(Map<String, dynamic> json,
@@ -1194,7 +1088,6 @@ class PrinterService {
   }
 
   void _showExceptionSnackbar(Object e, StackTrace s) {
-
     _snackBarService.show(SnackBarConfig.stacktraceDialog(
       dialogService: _dialogService,
       exception: e,

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -589,70 +589,43 @@ class PrinterService {
     printer.printFan = PrintFan.partialUpdate(printer.printFan, jsonResponse);
   }
 
-  _updateHeaterFan(String configName, Map<String, dynamic> fanJson,
+  _updateHeaterFan(String fanName, Map<String, dynamic> fanJson,
       {required PrinterBuilder printer}) {
-    if (!fanJson.containsKey('speed')) {
-      return;
-    }
-
-    final HeaterFan curFan = printer.fans[configName]! as HeaterFan;
-
+    final HeaterFan curFan = printer.fans[fanName]! as HeaterFan;
     printer.fans = {
       ...printer.fans,
-      configName: curFan.copyWith(speed: fanJson['speed'])
+      fanName: HeaterFan.partialUpdate(curFan, fanJson)
     };
   }
 
-  _updateControllerFan(String configName, Map<String, dynamic> fanJson,
+  _updateControllerFan(String fanName, Map<String, dynamic> fanJson,
       {required PrinterBuilder printer}) {
-    if (!fanJson.containsKey('speed')) {
-      return;
-    }
-
-    final ControllerFan curFan = printer.fans[configName]! as ControllerFan;
+    final ControllerFan curFan = printer.fans[fanName]! as ControllerFan;
 
     printer.fans = {
       ...printer.fans,
-      configName: curFan.copyWith(speed: fanJson['speed'])
+      fanName: ControllerFan.partialUpdate(curFan, fanJson)
     };
   }
 
-  _updateTemperatureFan(String configName, Map<String, dynamic> fanJson,
+  _updateTemperatureFan(String fanName, Map<String, dynamic> fanJson,
       {required PrinterBuilder printer}) {
-    if (!fanJson.containsKey('speed') &&
-        !fanJson.containsKey('rpm') &&
-        !fanJson.containsKey('temperature') &&
-        !fanJson.containsKey('target')) {
-      return;
-    }
+    final TemperatureFan curFan = printer.fans[fanName]! as TemperatureFan;
 
-    final TemperatureFan curFan = printer.fans[configName]! as TemperatureFan;
-
+    //TODO add TempHistory
     printer.fans = {
       ...printer.fans,
-      configName: curFan.copyWith(
-        speed: fanJson['speed'] ?? curFan.speed,
-        rpm: fanJson['rpm'] ?? curFan.rpm,
-        temperature: fanJson['temperature'] ?? curFan.temperature,
-        target: fanJson['target'] ?? curFan.target,
-      )
+      fanName: TemperatureFan.partialUpdate(curFan, fanJson)
     };
   }
 
-  _updateGenericFan(String configName, Map<String, dynamic> fanJson,
+  _updateGenericFan(String fanName, Map<String, dynamic> fanJson,
       {required PrinterBuilder printer}) {
-    if (!fanJson.containsKey('speed')) {
-      return;
-    }
-    if (!fanJson.containsKey('speed')) {
-      return;
-    }
-
-    final GenericFan curFan = printer.fans[configName]! as GenericFan;
+    final GenericFan curFan = printer.fans[fanName]! as GenericFan;
 
     printer.fans = {
       ...printer.fans,
-      configName: curFan.copyWith(speed: fanJson['speed'])
+      fanName: GenericFan.partialUpdate(curFan, fanJson)
     };
   }
 

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -631,46 +631,21 @@ class PrinterService {
 
   _updateTemperatureSensor(String configName, Map<String, dynamic> sensorJson,
       {required PrinterBuilder printer}) {
-    TemperatureSensor curTmpSensor = printer.temperatureSensors[configName]!;
-
-    List<double>? temperatureHistory =
-        (sensorJson['temperatures'] as List<dynamic>?)?.cast<double>() ??
-            curTmpSensor.temperatureHistory;
-    DateTime? lastHistory;
-
-    // Update temp cache for graphs!
-    DateTime now = DateTime.now();
-    if (now.difference(curTmpSensor.lastHistory).inSeconds >= 1) {
-      temperatureHistory = _updateHistoryList(curTmpSensor.temperatureHistory,
-          sensorJson['temperature'] ?? curTmpSensor.temperature);
-      lastHistory = now;
-    }
+    TemperatureSensor current = printer.temperatureSensors[configName]!;
 
     printer.temperatureSensors = {
       ...printer.temperatureSensors,
-      configName: curTmpSensor.copyWith(
-        temperature: sensorJson['temperature'] ?? curTmpSensor.temperature,
-        measuredMinTemp:
-            sensorJson['measured_min_temp'] ?? curTmpSensor.measuredMinTemp,
-        measuredMaxTemp:
-            sensorJson['measured_max_temp'] ?? curTmpSensor.measuredMaxTemp,
-        lastHistory: lastHistory ?? curTmpSensor.lastHistory,
-        temperatureHistory:
-            temperatureHistory ?? curTmpSensor.temperatureHistory,
-      )
+      configName: TemperatureSensor.partialUpdate(current, sensorJson)
     };
   }
 
   _updateOutputPin(String pin, Map<String, dynamic> pinJson,
       {required PrinterBuilder printer}) {
     OutputPin curPin = printer.outputPins[pin]!;
-    if (!pinJson.containsKey('value')) {
-      return;
-    }
 
     printer.outputPins = {
       ...printer.outputPins,
-      pin: curPin.copyWith(value: pinJson['value'])
+      pin: OutputPin.partialUpdate(curPin, pinJson)
     };
   }
 

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -720,82 +720,27 @@ class PrinterService {
         MotionReport.partialUpdate(printer.motionReport, jsonResponse);
   }
 
-  _updateDisplayStatus(Map<String, dynamic> json,
+  _updateDisplayStatus(Map<String, dynamic> jsonResponse,
       {required PrinterBuilder printer}) {
-    double? progress = json['progress'];
-    String? message = json['message'];
-
-    DisplayStatus old = printer.displayStatus ?? const DisplayStatus();
-
-    printer.displayStatus = DisplayStatus(
-      progress: progress ?? old.progress,
-      message: message,
+    printer.displayStatus = DisplayStatus.partialUpdate(
+      printer.displayStatus,
+      jsonResponse,
     );
   }
 
-  _updateVirtualSd(Map<String, dynamic> virtualSDJson,
+  _updateVirtualSd(Map<String, dynamic> jsonResponse,
       {required PrinterBuilder printer}) {
-    double? progress;
-    bool? isActive;
-    int? filePosition;
-
-    if (virtualSDJson.containsKey('progress')) {
-      progress = virtualSDJson['progress'];
-    }
-    if (virtualSDJson.containsKey('is_active')) {
-      isActive = virtualSDJson['is_active'];
-    }
-    if (virtualSDJson.containsKey('file_position')) {
-      filePosition =
-          int.tryParse(virtualSDJson['file_position'].toString()) ?? 0;
-    }
-    VirtualSdCard old = printer.virtualSdCard ?? const VirtualSdCard();
-    printer.virtualSdCard = old.copyWith(
-        progress: progress ?? old.progress,
-        isActive: isActive ?? old.isActive,
-        filePosition: filePosition ?? old.filePosition);
+    printer.virtualSdCard =
+        VirtualSdCard.partialUpdate(printer.virtualSdCard, jsonResponse);
   }
 
-  _updatePrintStat(Map<String, dynamic> printStatJson,
+  _updatePrintStat(Map<String, dynamic> jsonResponse,
       {required PrinterBuilder printer}) {
-    PrintState? state;
-    double? totalDuration;
-    double? printDuration;
-    double? filamentUsed;
-    String? message;
-    String? filename;
+    if (jsonResponse.containsKey('message')) {
+      _onMessage(jsonResponse['message']!);
+    }
 
-    if (printStatJson.containsKey('state')) {
-      state =
-          EnumToString.fromString(PrintState.values, printStatJson['state']) ??
-              PrintState.error;
-    }
-    if (printStatJson.containsKey('filename')) {
-      filename = printStatJson['filename'];
-    }
-    if (printStatJson.containsKey('total_duration')) {
-      totalDuration = printStatJson['total_duration'];
-    }
-    if (printStatJson.containsKey('print_duration')) {
-      printDuration = printStatJson['print_duration'];
-    }
-    if (printStatJson.containsKey('filament_used')) {
-      filamentUsed = printStatJson['filament_used'];
-    }
-    if (printStatJson.containsKey('message')) {
-      message = printStatJson['message'];
-      _onMessage(message!);
-    }
-    PrintStats old = printer.print ?? const PrintStats();
-
-    printer.print = PrintStats(
-      state: state ?? old.state,
-      totalDuration: totalDuration ?? old.totalDuration,
-      printDuration: printDuration ?? old.printDuration,
-      filamentUsed: filamentUsed ?? old.filamentUsed,
-      message: message ?? old.message,
-      filename: filename ?? old.filename,
-    );
+    printer.print = PrintStats.partialUpdate(printer.print, jsonResponse);
   }
 
   _updateConfigFile(Map<String, dynamic> printStatJson,

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -727,24 +727,8 @@ class PrinterService {
 
   _updateLed(String led, Map<String, dynamic> ledJson,
       {required PrinterBuilder printer}) {
-    if (!ledJson.containsKey('color_data')) {
-      return;
-    }
-
-    List<dynamic> colorData = ledJson['color_data'];
-    var pixels = colorData
-        .map((e) => Pixel.fromList(e.cast<double>()))
-        .toList(growable: false);
-
     final Led curLed = printer.leds[led]!;
-
-    if (curLed is DumbLed) {
-      printer.leds = {...printer.leds, led: curLed.copyWith(color: pixels[0])};
-    } else if (curLed is AddressableLed) {
-      printer.leds = {...printer.leds, led: curLed.copyWith(pixels: pixels)};
-    } else {
-      throw UnsupportedError('The provided LED Type is not implemented yet!');
-    }
+    printer.leds = {...printer.leds, led: Led.partialUpdate(curLed, ledJson)};
   }
 
   Map<String, List<String>?> _queryPrinterObjectJson(

--- a/lib/service/moonraker/printer_service.dart
+++ b/lib/service/moonraker/printer_service.dart
@@ -584,16 +584,9 @@ class PrinterService {
     });
   }
 
-  _updatePrintFan(Map<String, dynamic> fanJson,
+  _updatePrintFan(Map<String, dynamic> jsonResponse,
       {required PrinterBuilder printer}) {
-    if (fanJson.containsKey('speed')) {
-      double speed = fanJson['speed'];
-      if (printer.printFan == null) {
-        printer.printFan = PrintFan(speed: speed);
-      } else {
-        printer.printFan = printer.printFan!.copyWith(speed: speed);
-      }
-    }
+    printer.printFan = PrintFan.partialUpdate(printer.printFan, jsonResponse);
   }
 
   _updateHeaterFan(String configName, Map<String, dynamic> fanJson,

--- a/lib/util/json_util.dart
+++ b/lib/util/json_util.dart
@@ -1,0 +1,12 @@
+List<T>? updateHistoryListInJson<T>(
+    Map<String, dynamic> inputJson, String listKey, String valueKey) {
+  var currentHistory = inputJson[listKey] as List<dynamic>?;
+  if (currentHistory == null) {
+    return null;
+  }
+  T toAdd = inputJson[valueKey];
+  if (currentHistory.length >= 1200) {
+    return [...currentHistory.sublist(1), toAdd];
+  }
+  return [...currentHistory, toAdd];
+}

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,0 +1,8 @@
+import 'dart:convert';
+
+/// Returns the ObjectsJson from the moonraker JSON result using
+/// /printer/objects/query?<OBJECT> Endpoint
+Map<String, dynamic> objectFromHttpApiResult(String input, String objectKey) {
+  var rawJson = jsonDecode(input);
+  return rawJson['result']['status'][objectKey];
+}

--- a/test/unit/marshalling/printer/addressable_led_marshalling_test.dart
+++ b/test/unit/marshalling/printer/addressable_led_marshalling_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/leds/addressable_led.dart';
+import 'package:mobileraker/data/dto/machine/leds/led.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('AddressableLed fromJson', () {
+    AddressableLed obj = addressableLedObject();
+
+    expect(obj, isNotNull);
+    expect(obj.name, equals('sb_leds'));
+    expect(
+        obj.pixels,
+        orderedEquals([
+          Pixel.fromList([0.44, 0.0, 0.10, 0.20]),
+          Pixel.fromList([0.0, 0.42, 0.69, 0.0]),
+          Pixel.fromList([0.0, 0.88, 0.0, 0.11])
+        ]));
+  });
+  test('AddressableLed partialUpdate from Led', () {
+    AddressableLed old = addressableLedObject();
+
+    var updateJson = {
+      "color_data": [
+        [0.88, 0.2, 0.55, 0.12],
+        [0.42, 0.0, 0.69, 0.2],
+      ]
+    };
+
+    var updatedObj = Led.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.name, equals('sb_leds'));
+    expect(updatedObj is AddressableLed, isTrue);
+    expect(
+        (updatedObj as AddressableLed).pixels,
+        orderedEquals([
+          Pixel.fromList([0.88, 0.2, 0.55, 0.12]),
+          Pixel.fromList([0.42, 0.0, 0.69, 0.2])
+        ]));
+  });
+
+  test('AddressableLed partialUpdate - pixels', () {
+    AddressableLed old = addressableLedObject();
+
+    var updateJson = {
+      "color_data": [
+        [0.88, 0.2, 0.55, 0.12],
+        [0.42, 0.0, 0.69, 0.2],
+      ]
+    };
+
+    var updatedObj = AddressableLed.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.name, equals('sb_leds'));
+    expect(
+        updatedObj.pixels,
+        orderedEquals([
+          Pixel.fromList([0.88, 0.2, 0.55, 0.12]),
+          Pixel.fromList([0.42, 0.0, 0.69, 0.2])
+        ]));
+  });
+}
+
+AddressableLed addressableLedObject() {
+  String input =
+      '{"result": {"status": {"neopixel sb_leds": {"color_data": [[0.44, 0.0, 0.10, 0.20], [0.0, 0.42, 0.69, 0.0], [0.0, 0.88, 0.0, 0.11]]}}, "eventtime": 4327798.835161627}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "neopixel sb_leds");
+
+  return AddressableLed.fromJson(jsonRaw, "sb_leds");
+}

--- a/test/unit/marshalling/printer/controller_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/controller_fan_marshalling_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/fans/controller_fan.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('ControllerFan fromJson', () {
+    ControllerFan obj = ControllerFanObject();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+  });
+  test('ControllerFan partialUpdate - speed', () {
+    ControllerFan old = ControllerFanObject();
+
+    var updateJson = {"speed": 0.99};
+
+    var updatedObj = ControllerFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.99));
+  });
+}
+
+ControllerFan ControllerFanObject() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": null}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return ControllerFan.fromJson(jsonRaw, "testFan");
+}

--- a/test/unit/marshalling/printer/display_status_marshalling_test.dart
+++ b/test/unit/marshalling/printer/display_status_marshalling_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/display_status.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('DisplayStatus fromJson', () {
+    DisplayStatus displayStatus = DisplayStatusObject();
+
+    expect(displayStatus, isNotNull);
+    expect(displayStatus.progress, equals(0));
+    expect(displayStatus.message, equals('Lala 123'));
+  });
+
+  group('DisplayStatus partialUpdate', () {
+    test('progress', () {
+      DisplayStatus old = DisplayStatusObject();
+
+      var updateJson = {"progress": 0.52};
+
+      var updatedObj = DisplayStatus.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.52));
+      expect(updatedObj.message, equals('Lala 123'));
+    });
+
+    test('message', () {
+      DisplayStatus old = DisplayStatusObject();
+
+      var updateJson = {"message": 'Lorem'};
+
+      var updatedObj = DisplayStatus.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0));
+      expect(updatedObj.message, equals('Lorem'));
+    });
+
+    test('message set to null', () {
+      DisplayStatus old = DisplayStatusObject();
+
+      var updateJson = {"message": null};
+
+      var updatedObj = DisplayStatus.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0));
+      expect(updatedObj.message, isNull);
+    });
+
+    test('Full update', () {
+      DisplayStatus old = DisplayStatusObject();
+      String input =
+          '{"result": {"status": {"display_status": {"progress": 0.69, "message": "FuFU"}}, "eventtime": 3796193.028154784}}';
+
+      var updateJson = objectFromHttpApiResult(input, "display_status");
+
+      var updatedObj = DisplayStatus.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.69));
+      expect(updatedObj.message, equals('FuFU'));
+    });
+  });
+}
+
+DisplayStatus DisplayStatusObject() {
+  String input =
+      '{"result": {"status": {"display_status": {"progress": 0.0, "message": "Lala 123"}}, "eventtime": 3796193.028154784}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "display_status");
+
+  return DisplayStatus.fromJson(jsonRaw);
+}

--- a/test/unit/marshalling/printer/dumb_led_marshalling_test.dart
+++ b/test/unit/marshalling/printer/dumb_led_marshalling_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/leds/dumb_led.dart';
+import 'package:mobileraker/data/dto/machine/leds/led.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('DumbLed fromJson', () {
+    DumbLed obj = dumbLedObject();
+
+    expect(obj, isNotNull);
+    expect(obj.name, equals('caselight'));
+    expect(obj.color,
+        equals(const Pixel(red: 1, green: 1, blue: 0.11, white: 0.44)));
+  });
+  test('DumbLed partialUpdate from Led', () {
+    DumbLed old = dumbLedObject();
+
+    var updateJson = {
+      "color_data": [
+        [0.88, 0.2, 0.55, 0.12]
+      ]
+    };
+
+    var updatedObj = Led.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.name, equals('caselight'));
+    expect(updatedObj is DumbLed, isTrue);
+    expect((updatedObj as DumbLed).color,
+        equals(Pixel.fromList([0.88, 0.2, 0.55, 0.12])));
+  });
+  test('DumbLed partialUpdate - color', () {
+    DumbLed old = dumbLedObject();
+
+    var updateJson = {
+      "color_data": [
+        [0.88, 0.2, 0.55, 0.12]
+      ]
+    };
+
+    var updatedObj = DumbLed.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.name, equals('caselight'));
+    expect(updatedObj.color, equals(Pixel.fromList([0.88, 0.2, 0.55, 0.12])));
+  });
+}
+
+DumbLed dumbLedObject() {
+  String input =
+      '{"result": {"status": {"led caselight": {"color_data": [[1.0, 1.0, 0.11, 0.44]]}}, "eventtime": 4328671.506395617}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "led caselight");
+
+  return DumbLed.fromJson(jsonRaw, "caselight");
+}

--- a/test/unit/marshalling/printer/exclude_object_marshalling_test.dart
+++ b/test/unit/marshalling/printer/exclude_object_marshalling_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/exclude_object.dart';
+import 'package:vector_math/vector_math.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('ExcludeObject fromJson', () {
+    ExcludeObject obj = excludeObjectObject();
+
+    expect(obj, isNotNull);
+    expect(obj.currentObject, equals("Teeest"));
+    expect(obj.excludedObjects, isEmpty);
+    expect(obj.objects.length, equals(1));
+    expect(obj.objects.first.name, equals("BODY-2.STL_ID_0_COPY_0"));
+    expect(obj.objects.first.center, equals(Vector2(125, 105)));
+    expect(obj.objects.first.polygons, isNotEmpty);
+    expect(obj.objects.first.polygons.first, equals(Vector2(74.9772, 96.085)));
+    expect(obj.objects.first.polygons.last, equals(Vector2(72.9772, 95.085)));
+  });
+
+  group('ExcludeObject partialUpdate', () {
+    test('current_object', () {
+      ExcludeObject old = excludeObjectObject();
+
+      var updateJson = {"current_object": "rofl"};
+
+      var updatedObj = ExcludeObject.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.currentObject, equals("rofl"));
+      expect(updatedObj.excludedObjects, isEmpty);
+      expect(updatedObj.objects.length, equals(1));
+      expect(updatedObj.objects.first.name, equals("BODY-2.STL_ID_0_COPY_0"));
+      expect(updatedObj.objects.first.center, equals(Vector2(125, 105)));
+      expect(updatedObj.objects.first.polygons, isNotEmpty);
+      expect(updatedObj.objects.first.polygons.first,
+          equals(Vector2(74.9772, 96.085)));
+      expect(updatedObj.objects.first.polygons.last,
+          equals(Vector2(72.9772, 95.085)));
+    });
+
+    test('excluded_objects', () {
+      ExcludeObject old = excludeObjectObject();
+
+      var updateJson = {
+        "excluded_objects": ["obj1", "obj2"]
+      };
+
+      var updatedObj = ExcludeObject.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.currentObject, equals("Teeest"));
+      expect(updatedObj.excludedObjects, orderedEquals(["obj1", "obj2"]));
+      expect(updatedObj.objects.length, equals(1));
+      expect(updatedObj.objects.first.name, equals("BODY-2.STL_ID_0_COPY_0"));
+      expect(updatedObj.objects.first.center, equals(Vector2(125, 105)));
+      expect(updatedObj.objects.first.polygons, isNotEmpty);
+      expect(updatedObj.objects.first.polygons.first,
+          equals(Vector2(74.9772, 96.085)));
+      expect(updatedObj.objects.first.polygons.last,
+          equals(Vector2(72.9772, 95.085)));
+    });
+  });
+}
+
+ExcludeObject excludeObjectObject() {
+  String input =
+      '{"result": {"status": {"exclude_object":{"objects":[{"name":"BODY-2.STL_ID_0_COPY_0","center":[125,105],"polygon":[[74.9772,96.085],[102.192,85.1634],[102.714,85.0411],[103.249,85],[148.292,85],[148.826,85.0411],[149.349,85.1634],[149.846,85.3641],[175.023,97.3141],[175.023,101],[174.993,101.491],[174.974,101.626],[174.902,101.975],[174.827,102.236],[174.753,102.444],[174.587,102.816],[174.547,102.891],[174.259,103.351],[174.188,103.446],[173.851,103.828],[173.781,103.897],[173.374,104.236],[173.31,104.282],[172.839,104.564],[172.786,104.59],[131.747,124.81],[131.278,124.952],[130.79,125],[119.313,125],[118.098,124.958],[116.889,124.831],[115.692,124.621],[114.512,124.329],[113.356,123.955],[112.228,123.502],[111.134,122.971],[79.0261,106.609],[78.3738,106.263],[78.294,106.214],[77.712,105.812],[77.6139,105.735],[77.106,105.288],[76.9954,105.179],[76.5638,104.699],[76.4473,104.553],[76.0924,104.052],[75.9772,103.867],[75.7669,103.491],[75.698,103.355],[75.568,103.076],[75.3858,102.618],[75.2418,102.166],[75.1598,101.85],[75.1259,101.697],[75.0436,101.219],[75.023,101.061],[74.9936,100.734],[74.9772,100.261],[72.9772,95.085]]}],"excluded_objects":[],"current_object":"Teeest"}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "exclude_object");
+
+  return ExcludeObject.fromJson(jsonRaw);
+}

--- a/test/unit/marshalling/printer/extruder_marshalling_test.dart
+++ b/test/unit/marshalling/printer/extruder_marshalling_test.dart
@@ -3,6 +3,8 @@ import 'package:mobileraker/data/dto/machine/extruder.dart';
 
 import '../../../test_utils.dart';
 
+var NOW = DateTime.now();
+
 void main() {
   test('Extruder fromJson', () {
     var extruder = extruderObject();
@@ -13,6 +15,7 @@ void main() {
     expect(extruder.pressureAdvance, equals(0.055));
     expect(extruder.smoothTime, equals(0.04));
     expect(extruder.power, equals(0));
+    expect(extruder.lastHistory, equals(NOW));
     expect(extruder.temperatureHistory, isNull);
     expect(extruder.targetHistory, isNull);
     expect(extruder.powerHistory, isNull);
@@ -34,6 +37,7 @@ void main() {
     expect(extruder.pressureAdvance, equals(0.055));
     expect(extruder.smoothTime, equals(0.99));
     expect(extruder.power, equals(1));
+    expect(extruder.lastHistory, equals(NOW));
     expect(extruder.temperatureHistory, isNull);
     expect(extruder.targetHistory, isNull);
     expect(extruder.powerHistory, isNull);
@@ -56,6 +60,7 @@ void main() {
     expect(extruder.pressureAdvance, equals(0.055));
     expect(extruder.smoothTime, equals(0.04));
     expect(extruder.power, equals(0));
+    expect(extruder.lastHistory, equals(NOW));
     expect(extruder.temperatureHistory,
         orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
     expect(extruder.targetHistory,
@@ -73,6 +78,5 @@ Extruder extruderObject() {
   return Extruder.fromJson({
     ...parsedJson,
     "num": 0,
-    "lastHistory": DateTime.now().toIso8601String()
-  });
+    "lastHistory": NOW.toIso8601String()});
 }

--- a/test/unit/marshalling/printer/extruder_marshalling_test.dart
+++ b/test/unit/marshalling/printer/extruder_marshalling_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/extruder.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('Extruder fromJson', () {
+    var extruder = extruderObject();
+
+    expect(extruder, isNotNull);
+    expect(extruder.temperature, equals(22.56));
+    expect(extruder.target, equals(0));
+    expect(extruder.pressureAdvance, equals(0.055));
+    expect(extruder.smoothTime, equals(0.04));
+    expect(extruder.power, equals(0));
+    expect(extruder.temperatureHistory, isNull);
+    expect(extruder.targetHistory, isNull);
+    expect(extruder.powerHistory, isNull);
+  });
+
+  test('Extruder partialUpdate', () {
+    var old = extruderObject();
+
+    var parsedJson = {
+      "power": 1.0,
+      "smooth_time": .99,
+    };
+
+    var extruder = Extruder.partialUpdate(old, parsedJson);
+
+    expect(extruder, isNotNull);
+    expect(extruder.temperature, equals(22.56));
+    expect(extruder.target, equals(0));
+    expect(extruder.pressureAdvance, equals(0.055));
+    expect(extruder.smoothTime, equals(0.99));
+    expect(extruder.power, equals(1));
+    expect(extruder.temperatureHistory, isNull);
+    expect(extruder.targetHistory, isNull);
+    expect(extruder.powerHistory, isNull);
+  });
+
+  test('Extruder partialUpdate - temperature History', () {
+    var old = extruderObject();
+
+    var parsedJson = {
+      "powers": [0, 0, 0, 0, 0.5, 0.9, 1.0],
+      "temperatures": [30, 30, 31, 31, 32.5, 44, 45, 45, 9],
+      "targets": [0, 0, 0, 1.4, 2, 3, 4, 5, 6, 7, 8, 8, 9],
+    };
+
+    var extruder = Extruder.partialUpdate(old, parsedJson);
+
+    expect(extruder, isNotNull);
+    expect(extruder.temperature, equals(22.56));
+    expect(extruder.target, equals(0));
+    expect(extruder.pressureAdvance, equals(0.055));
+    expect(extruder.smoothTime, equals(0.04));
+    expect(extruder.power, equals(0));
+    expect(extruder.temperatureHistory,
+        orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
+    expect(extruder.targetHistory,
+        orderedEquals([0, 0, 0, 1.4, 2, 3, 4, 5, 6, 7, 8, 8, 9]));
+    expect(extruder.powerHistory, orderedEquals([0, 0, 0, 0, 0.5, 0.9, 1.0]));
+  });
+}
+
+Extruder extruderObject() {
+  String input =
+      '{"result": {"status": {"extruder": {"motion_queue": null, "pressure_advance": 0.055, "temperature": 22.56, "power": 0.0, "can_extrude": false, "smooth_time": 0.04, "target": 0.0}}, "eventtime": 3792148.053680181}}';
+
+  var parsedJson = objectFromHttpApiResult(input, "extruder");
+
+  return Extruder.fromJson({
+    ...parsedJson,
+    "num": 0,
+    "lastHistory": DateTime.now().toIso8601String()
+  });
+}

--- a/test/unit/marshalling/printer/gcode_move_marshalling_test.dart
+++ b/test/unit/marshalling/printer/gcode_move_marshalling_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/gcode_move.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('GCodeMove fromJson', () {
+    var gcodeMove = gcodeMoveObject();
+
+    expect(gcodeMove, isNotNull);
+    expect(gcodeMove.speedFactor, equals(1.23));
+    expect(gcodeMove.speed, equals(1500));
+    expect(gcodeMove.extrudeFactor, equals(0.71));
+    expect(gcodeMove.absoluteCoordinates, isTrue);
+    expect(gcodeMove.absoluteExtrude, isFalse);
+    expect(gcodeMove.homingOrigin, orderedEquals([1.1, 2.2, 3.3, 4.4]));
+    expect(gcodeMove.gcodePosition, orderedEquals([0.0, 1.1, 2.2, 3.3]));
+    expect(gcodeMove.position, orderedEquals([0, 1, 2, 3]));
+  });
+
+  test('GCodeMove partialUpdate', () {
+    var gcodeMove = gcodeMoveObject();
+
+    var parsedJson = {
+      "homing_origin": [0, 23.4, 11.0, 0],
+      "speed_factor": 2.24,
+    };
+
+    var gcodeMoveUpdated = GCodeMove.partialUpdate(gcodeMove, parsedJson);
+
+    expect(gcodeMoveUpdated.speedFactor, equals(2.24));
+    expect(gcodeMoveUpdated.speed, equals(1500));
+    expect(gcodeMoveUpdated.extrudeFactor, equals(0.71));
+    expect(gcodeMoveUpdated.absoluteCoordinates, isTrue);
+    expect(gcodeMoveUpdated.absoluteExtrude, isFalse);
+    expect(gcodeMoveUpdated.homingOrigin, orderedEquals([0, 23.4, 11.0, 0]));
+    expect(gcodeMoveUpdated.gcodePosition, orderedEquals([0.0, 1.1, 2.2, 3.3]));
+    expect(gcodeMoveUpdated.position, orderedEquals([0, 1, 2, 3]));
+  });
+
+  test('GCodeMove partialUpdate - Full update', () {
+    var gcodeMove = gcodeMoveObject();
+
+    String update =
+        '{"result": {"status": {"gcode_move": {"homing_origin": [0,0,0,0], "speed_factor": 0.2, "gcode_position": [3.3,0,0,1.0], "absolute_extrude": true, "absolute_coordinates": false, "position": [0, 1, 2, 3], "speed": 1500.0, "extrude_factor": 0.71}}, "eventtime": 3790887.876200505}}';
+
+    var parsedJson = objectFromHttpApiResult(update, "gcode_move");
+
+    var gcodeMoveUpdated = GCodeMove.partialUpdate(gcodeMove, parsedJson);
+
+    expect(gcodeMoveUpdated, isNotNull);
+    expect(gcodeMoveUpdated.speedFactor, equals(.2));
+    expect(gcodeMoveUpdated.speed, equals(1500));
+    expect(gcodeMoveUpdated.extrudeFactor, equals(0.71));
+    expect(gcodeMoveUpdated.absoluteCoordinates, isFalse);
+    expect(gcodeMoveUpdated.absoluteExtrude, isTrue);
+    expect(gcodeMoveUpdated.homingOrigin, orderedEquals([0, 0, 0, 0]));
+    expect(gcodeMoveUpdated.gcodePosition, orderedEquals([3.3, 0, 0, 1.0]));
+    expect(gcodeMoveUpdated.position, orderedEquals([0, 1, 2, 3]));
+  });
+}
+
+GCodeMove gcodeMoveObject() {
+  String input =
+      '{"result": {"status": {"gcode_move": {"homing_origin": [1.1, 2.2, 3.3, 4.4], "speed_factor": 1.23, "gcode_position": [0.0, 1.1, 2.2, 3.3], "absolute_extrude": false, "absolute_coordinates": true, "position": [0, 1, 2, 3], "speed": 1500.0, "extrude_factor": 0.71}}, "eventtime": 3790887.876200505}}';
+
+  var parsedJson = objectFromHttpApiResult(input, "gcode_move");
+
+  return GCodeMove.fromJson(parsedJson);
+}

--- a/test/unit/marshalling/printer/generic_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/generic_fan_marshalling_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/fans/generic_fan.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('GenericFan fromJson', () {
+    GenericFan obj = GenericFanObject();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+  });
+  test('GenericFan partialUpdate - speed', () {
+    GenericFan old = GenericFanObject();
+
+    var updateJson = {"speed": 0.99};
+
+    var updatedObj = GenericFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.99));
+  });
+}
+
+GenericFan GenericFanObject() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": null}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return GenericFan.fromJson(jsonRaw, "testFan");
+}

--- a/test/unit/marshalling/printer/heater_bed_marshalling_test.dart
+++ b/test/unit/marshalling/printer/heater_bed_marshalling_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/heater_bed.dart';
+
+import '../../../test_utils.dart';
+
+var NOW = DateTime.now();
+
+void main() {
+  test('HeaterBed fromJson', () {
+    var heaterBed = HeaterBedObject();
+
+    expect(heaterBed, isNotNull);
+    expect(heaterBed.temperature, equals(23.14));
+    expect(heaterBed.target, equals(11.5));
+    expect(heaterBed.power, equals(0));
+    expect(heaterBed.lastHistory, equals(NOW));
+    expect(heaterBed.temperatureHistory, isNull);
+    expect(heaterBed.targetHistory, isNull);
+    expect(heaterBed.powerHistory, isNull);
+  });
+
+  test('HeaterBed partialUpdate', () {
+    var old = HeaterBedObject();
+
+    var parsedJson = {
+      "power": 1.0,
+      "temperature": 224.5,
+    };
+
+    var heaterBed = HeaterBed.partialUpdate(old, parsedJson);
+
+    expect(heaterBed, isNotNull);
+    expect(heaterBed.temperature, equals(224.5));
+    expect(heaterBed.target, equals(11.5));
+    expect(heaterBed.power, equals(1.0));
+    expect(heaterBed.lastHistory, equals(NOW));
+    expect(heaterBed.temperatureHistory, isNull);
+    expect(heaterBed.targetHistory, isNull);
+    expect(heaterBed.powerHistory, isNull);
+  });
+
+  test('HeaterBed partialUpdate - temperature History', () {
+    var old = HeaterBedObject();
+
+    var parsedJson = {
+      "powers": [0, 0, 0, 0, 0.5, 0.9, 1.0],
+      "temperatures": [30, 30, 31, 31, 32.5, 44, 45, 45, 9],
+      "targets": [0, 0, 0, 1.4, 2, 3, 4, 5, 6, 7, 8, 8, 9],
+    };
+
+    var heaterBed = HeaterBed.partialUpdate(old, parsedJson);
+
+    expect(heaterBed, isNotNull);
+    expect(heaterBed.temperature, equals(23.14));
+    expect(heaterBed.target, equals(11.5));
+    expect(heaterBed.power, equals(0));
+    expect(heaterBed.lastHistory, equals(NOW));
+
+    expect(heaterBed.temperatureHistory,
+        orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
+    expect(heaterBed.targetHistory,
+        orderedEquals([0, 0, 0, 1.4, 2, 3, 4, 5, 6, 7, 8, 8, 9]));
+    expect(heaterBed.powerHistory, orderedEquals([0, 0, 0, 0, 0.5, 0.9, 1.0]));
+  });
+}
+
+HeaterBed HeaterBedObject() {
+  String input =
+      '{"result": {"status": {"heater_bed": {"temperature": 23.14, "power": 0.0, "target": 11.5}}, "eventtime": 3793416.674978863}}';
+
+  var parsedJson = objectFromHttpApiResult(input, "heater_bed");
+
+  return HeaterBed.fromJson(
+      {...parsedJson, "lastHistory": NOW.toIso8601String()});
+}

--- a/test/unit/marshalling/printer/heater_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/heater_fan_marshalling_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/fans/heater_fan.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('HeaterFan fromJson', () {
+    HeaterFan obj = HeaterFanObject();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+  });
+  test('HeaterFan partialUpdate - speed', () {
+    HeaterFan old = HeaterFanObject();
+
+    var updateJson = {"speed": 0.99};
+
+    var updatedObj = HeaterFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.99));
+  });
+}
+
+HeaterFan HeaterFanObject() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": null}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return HeaterFan.fromJson(jsonRaw, "testFan");
+}

--- a/test/unit/marshalling/printer/motion_report_marshalling_test.dart
+++ b/test/unit/marshalling/printer/motion_report_marshalling_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/motion_report.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('MotionReport fromJson', () {
+    MotionReport motionReport = motionReportObject();
+
+    expect(motionReport, isNotNull);
+    expect(motionReport.livePosition, orderedEquals([1.1, 2.2, 3.3, 4.4]));
+    expect(motionReport.liveVelocity, equals(11.4));
+    expect(motionReport.liveExtruderVelocity, equals(5.2));
+  });
+
+  test('MotionReport partialUpdate', () {
+    MotionReport motionReport = motionReportObject();
+
+    var motionReportJson = {
+      "live_position": [0.0, 4, 4, 22]
+    };
+
+    var motionReportUpdated =
+        MotionReport.partialUpdate(motionReport, motionReportJson);
+
+    expect(motionReportUpdated, isNotNull);
+    expect(motionReportUpdated.livePosition, orderedEquals([0.0, 4, 4, 22]));
+    expect(motionReport.liveVelocity, equals(11.4));
+    expect(motionReport.liveExtruderVelocity, equals(5.2));
+  });
+
+  test('MotionReport partialUpdate -  Full update', () {
+    MotionReport motionReport = motionReportObject();
+
+    String update =
+        '{"result": {"status": {"motion_report": {"live_position": [0.0,1,2,3], "steppers": ["extruder", "stepper_x", "stepper_y", "stepper_z", "stepper_z1", "stepper_z2", "stepper_z3"], "live_velocity": 44.4, "live_extruder_velocity": 0, "trapq": ["extruder", "toolhead"]}}, "eventtime": 3790039.864765516}}';
+
+    var motionReportJson = objectFromHttpApiResult(update, "motion_report");
+
+    var motionReportUpdated =
+        MotionReport.partialUpdate(motionReport, motionReportJson);
+
+    expect(motionReportUpdated, isNotNull);
+    expect(motionReportUpdated.livePosition, orderedEquals([0, 1, 2, 3]));
+    expect(motionReportUpdated.liveVelocity, equals(44.4));
+    expect(motionReportUpdated.liveExtruderVelocity, equals(0));
+  });
+}
+
+MotionReport motionReportObject() {
+  String input =
+      '{"result": {"status": {"motion_report": {"live_position": [1.1, 2.2, 3.3, 4.4], "steppers": ["extruder", "stepper_x", "stepper_y", "stepper_z", "stepper_z1", "stepper_z2", "stepper_z3"], "live_velocity": 11.4, "live_extruder_velocity": 5.2, "trapq": ["extruder", "toolhead"]}}, "eventtime": 3790039.864765516}}';
+
+  var motionReportJson = objectFromHttpApiResult(input, "motion_report");
+
+  var motionReport = MotionReport.fromJson(motionReportJson);
+  return motionReport;
+}

--- a/test/unit/marshalling/printer/output_pin_marshalling_test.dart
+++ b/test/unit/marshalling/printer/output_pin_marshalling_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/output_pin.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('OutputPin fromJson', () {
+    OutputPin obj = outputPinObject();
+
+    expect(obj, isNotNull);
+    expect(obj.name, equals("TEST"));
+    expect(obj.value, equals(0));
+  });
+  test('OutputPin partialUpdate - value', () {
+    OutputPin old = outputPinObject();
+
+    var updateJson = {"value": 0.99};
+
+    var updatedObj = OutputPin.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.name, equals("TEST"));
+    expect(updatedObj.value, equals(0.99));
+  });
+}
+
+OutputPin outputPinObject() {
+  String input =
+      '{"result": {"status": {"output_pin beeper": {"value": 0.0}}, "eventtime": 4231669.605721319}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "output_pin beeper");
+
+  return OutputPin.fromJson(jsonRaw, "TEST");
+}

--- a/test/unit/marshalling/printer/print_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/print_fan_marshalling_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/fans/print_fan.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('PrintFan fromJson', () {
+    PrintFan obj = printFanObject();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+  });
+  test('PrintFan partialUpdate - speed', () {
+    PrintFan old = printFanObject();
+
+    var updateJson = {"speed": 0.99};
+
+    var updatedObj = PrintFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.99));
+  });
+}
+
+PrintFan printFanObject() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": null}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return PrintFan.fromJson(jsonRaw);
+}

--- a/test/unit/marshalling/printer/print_stats_marshalling_test.dart
+++ b/test/unit/marshalling/printer/print_stats_marshalling_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/print_stats.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('PrintStats fromJson', () {
+    var obj = PrintStatsObject();
+
+    expect(obj, isNotNull);
+    expect(obj.state, equals(PrintState.standby));
+    expect(obj.totalDuration, equals(100.00));
+    expect(obj.printDuration, equals(0));
+    expect(obj.filamentUsed, equals(123.4));
+    expect(obj.message, equals(''));
+    expect(obj.filename, equals(''));
+  });
+
+  group('PrintStats partialUpdate', () {
+    test('state', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"state": 'error'};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.error));
+      expect(updatedObj.totalDuration, equals(100.00));
+      expect(updatedObj.printDuration, equals(0));
+      expect(updatedObj.filamentUsed, equals(123.4));
+      expect(updatedObj.message, equals(''));
+      expect(updatedObj.filename, equals(''));
+    });
+
+    test('total_duration', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"total_duration": 44002};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.standby));
+      expect(updatedObj.totalDuration, equals(44002));
+      expect(updatedObj.printDuration, equals(0));
+      expect(updatedObj.filamentUsed, equals(123.4));
+      expect(updatedObj.message, equals(''));
+      expect(updatedObj.filename, equals(''));
+    });
+
+    test('print_duration', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"print_duration": 4444};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.standby));
+      expect(updatedObj.totalDuration, equals(100.00));
+      expect(updatedObj.printDuration, equals(4444));
+      expect(updatedObj.filamentUsed, equals(123.4));
+      expect(updatedObj.message, equals(''));
+      expect(updatedObj.filename, equals(''));
+    });
+
+    test('filament_used', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"filament_used": 123123.5};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.standby));
+      expect(updatedObj.totalDuration, equals(100.00));
+      expect(updatedObj.printDuration, equals(0));
+      expect(updatedObj.filamentUsed, equals(123123.5));
+      expect(updatedObj.message, equals(''));
+      expect(updatedObj.filename, equals(''));
+    });
+
+    test('message', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"message": 'Abababab'};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.standby));
+      expect(updatedObj.totalDuration, equals(100.00));
+      expect(updatedObj.printDuration, equals(0));
+      expect(updatedObj.filamentUsed, equals(123.4));
+      expect(updatedObj.message, equals('Abababab'));
+      expect(updatedObj.filename, equals(''));
+    });
+
+    test('filename', () {
+      var old = PrintStatsObject();
+
+      var updateJson = {"filename": 'abc/root.gcode'};
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.standby));
+      expect(updatedObj.totalDuration, equals(100.00));
+      expect(updatedObj.printDuration, equals(0));
+      expect(updatedObj.filamentUsed, equals(123.4));
+      expect(updatedObj.message, equals(''));
+      expect(updatedObj.filename, equals('abc/root.gcode'));
+    });
+
+    test('Full update', () {
+      PrintStats old = PrintStatsObject();
+      String input =
+          '{"result": {"status": {"print_stats": {"info": {"total_layer": null, "current_layer": null}, "print_duration": 1.0, "total_duration": 4.0, "filament_used": 12.4, "filename": "ff", "state": "complete", "message": "Done"}}, "eventtime": 3798698.261748828}}';
+
+      var updateJson = objectFromHttpApiResult(input, "print_stats");
+
+      var updatedObj = PrintStats.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.state, equals(PrintState.complete));
+      expect(updatedObj.totalDuration, equals(4.00));
+      expect(updatedObj.printDuration, equals(1));
+      expect(updatedObj.filamentUsed, equals(12.4));
+      expect(updatedObj.message, equals('Done'));
+      expect(updatedObj.filename, equals('ff'));
+    });
+  });
+}
+
+PrintStats PrintStatsObject() {
+  String input =
+      '{"result": {"status": {"print_stats": {"info": {"total_layer": null, "current_layer": null}, "print_duration": 0.0, "total_duration": 100.0, "filament_used": 123.4, "filename": "", "state": "standby", "message": ""}}, "eventtime": 3798698.261748828}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "print_stats");
+
+  return PrintStats.fromJson(jsonRaw);
+}

--- a/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
@@ -3,6 +3,8 @@ import 'package:mobileraker/data/dto/machine/fans/temperature_fan.dart';
 
 import '../../../test_utils.dart';
 
+var NOW = DateTime.now();
+
 void main() {
   test('TemperatureFan with RPM fromJson', () {
     TemperatureFan obj = temperatureFanObjectWithRpm();
@@ -12,6 +14,7 @@ void main() {
     expect(obj.rpm, equals(500));
     expect(obj.temperature, equals(11.1));
     expect(obj.target, equals(44.95));
+    expect(obj.lastHistory, equals(NOW));
   });
 
   test('TemperatureFan without RPM fromJson', () {
@@ -22,6 +25,7 @@ void main() {
     expect(obj.rpm, equals(null));
     expect(obj.temperature, equals(11.1));
     expect(obj.target, equals(44.95));
+    expect(obj.lastHistory, equals(NOW));
   });
 
   test('TemperatureFan partialUpdate - speed', () {
@@ -36,6 +40,7 @@ void main() {
     expect(updatedObj.rpm, equals(500));
     expect(updatedObj.temperature, equals(11.1));
     expect(updatedObj.target, equals(44.95));
+    expect(updatedObj.lastHistory, equals(NOW));
   });
 
   test('TemperatureFan partialUpdate - rpm', () {
@@ -50,6 +55,7 @@ void main() {
     expect(updatedObj.rpm, equals(1099));
     expect(updatedObj.temperature, equals(11.1));
     expect(updatedObj.target, equals(44.95));
+    expect(updatedObj.lastHistory, equals(NOW));
   });
 
   test('TemperatureFan partialUpdate - temperature', () {
@@ -64,6 +70,7 @@ void main() {
     expect(updatedObj.rpm, equals(500));
     expect(updatedObj.temperature, equals(99));
     expect(updatedObj.target, equals(44.95));
+    expect(updatedObj.lastHistory, equals(NOW));
   });
 
   test('TemperatureFan partialUpdate - target', () {
@@ -78,6 +85,7 @@ void main() {
     expect(updatedObj.rpm, equals(500));
     expect(updatedObj.temperature, equals(11.1));
     expect(updatedObj.target, equals(85.22));
+    expect(updatedObj.lastHistory, equals(NOW));
   });
 }
 
@@ -88,7 +96,7 @@ TemperatureFan temperatureFanObjectWithRpm() {
   var jsonRaw = objectFromHttpApiResult(input, "fan");
 
   return TemperatureFan.fromJson(
-      {...jsonRaw, 'lastHistory': DateTime.now().toIso8601String()}, "testFan");
+      {...jsonRaw, 'lastHistory': NOW.toIso8601String()}, "testFan");
 }
 
 TemperatureFan temperatureFanObjectWithoutRpm() {
@@ -98,5 +106,5 @@ TemperatureFan temperatureFanObjectWithoutRpm() {
   var jsonRaw = objectFromHttpApiResult(input, "fan");
 
   return TemperatureFan.fromJson(
-      {...jsonRaw, 'lastHistory': DateTime.now().toIso8601String()}, "testFan");
+      {...jsonRaw, 'lastHistory': NOW.toIso8601String()}, "testFan");
 }

--- a/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/fans/temperature_fan.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('TemperatureFan with RPM fromJson', () {
+    TemperatureFan obj = temperatureFanObjectWithRpm();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+    expect(obj.rpm, equals(500));
+    expect(obj.temperature, equals(11.1));
+    expect(obj.target, equals(44.95));
+  });
+
+  test('TemperatureFan without RPM fromJson', () {
+    TemperatureFan obj = temperatureFanObjectWithoutRpm();
+
+    expect(obj, isNotNull);
+    expect(obj.speed, equals(0.55));
+    expect(obj.rpm, equals(null));
+    expect(obj.temperature, equals(11.1));
+    expect(obj.target, equals(44.95));
+  });
+
+  test('TemperatureFan partialUpdate - speed', () {
+    TemperatureFan old = temperatureFanObjectWithRpm();
+
+    var updateJson = {"speed": 0.99};
+
+    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.99));
+    expect(updatedObj.rpm, equals(500));
+    expect(updatedObj.temperature, equals(11.1));
+    expect(updatedObj.target, equals(44.95));
+  });
+
+  test('TemperatureFan partialUpdate - rpm', () {
+    TemperatureFan old = temperatureFanObjectWithRpm();
+
+    var updateJson = {"rpm": 1099};
+
+    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.55));
+    expect(updatedObj.rpm, equals(1099));
+    expect(updatedObj.temperature, equals(11.1));
+    expect(updatedObj.target, equals(44.95));
+  });
+
+  test('TemperatureFan partialUpdate - temperature', () {
+    TemperatureFan old = temperatureFanObjectWithRpm();
+
+    var updateJson = {"temperature": 99};
+
+    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.55));
+    expect(updatedObj.rpm, equals(500));
+    expect(updatedObj.temperature, equals(99));
+    expect(updatedObj.target, equals(44.95));
+  });
+
+  test('TemperatureFan partialUpdate - target', () {
+    TemperatureFan old = temperatureFanObjectWithRpm();
+
+    var updateJson = {"target": 85.22};
+
+    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.speed, equals(0.55));
+    expect(updatedObj.rpm, equals(500));
+    expect(updatedObj.temperature, equals(11.1));
+    expect(updatedObj.target, equals(85.22));
+  });
+}
+
+TemperatureFan temperatureFanObjectWithRpm() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": 500, "temperature":11.1, "target": 44.95}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return TemperatureFan.fromJson(
+      {...jsonRaw, 'lastHistory': DateTime.now().toIso8601String()}, "testFan");
+}
+
+TemperatureFan temperatureFanObjectWithoutRpm() {
+  String input =
+      '{"result": {"status": {"fan": {"speed": 0.55, "rpm": null, "temperature":11.1, "target": 44.95}}, "eventtime": 3801252.15548827}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "fan");
+
+  return TemperatureFan.fromJson(
+      {...jsonRaw, 'lastHistory': DateTime.now().toIso8601String()}, "testFan");
+}

--- a/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
+++ b/test/unit/marshalling/printer/temperature_fan_marshalling_test.dart
@@ -28,64 +28,66 @@ void main() {
     expect(obj.lastHistory, equals(NOW));
   });
 
-  test('TemperatureFan partialUpdate - speed', () {
-    TemperatureFan old = temperatureFanObjectWithRpm();
+  group('TemperatureFan partialUpdate', () {
+    test('speed', () {
+      TemperatureFan old = temperatureFanObjectWithRpm();
 
-    var updateJson = {"speed": 0.99};
+      var updateJson = {"speed": 0.99};
 
-    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+      var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.speed, equals(0.99));
-    expect(updatedObj.rpm, equals(500));
-    expect(updatedObj.temperature, equals(11.1));
-    expect(updatedObj.target, equals(44.95));
-    expect(updatedObj.lastHistory, equals(NOW));
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.speed, equals(0.99));
+      expect(updatedObj.rpm, equals(500));
+      expect(updatedObj.temperature, equals(11.1));
+      expect(updatedObj.target, equals(44.95));
+      expect(updatedObj.lastHistory, equals(NOW));
+    });
 
-  test('TemperatureFan partialUpdate - rpm', () {
-    TemperatureFan old = temperatureFanObjectWithRpm();
+    test('rpm', () {
+      TemperatureFan old = temperatureFanObjectWithRpm();
 
-    var updateJson = {"rpm": 1099};
+      var updateJson = {"rpm": 1099};
 
-    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+      var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.speed, equals(0.55));
-    expect(updatedObj.rpm, equals(1099));
-    expect(updatedObj.temperature, equals(11.1));
-    expect(updatedObj.target, equals(44.95));
-    expect(updatedObj.lastHistory, equals(NOW));
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.speed, equals(0.55));
+      expect(updatedObj.rpm, equals(1099));
+      expect(updatedObj.temperature, equals(11.1));
+      expect(updatedObj.target, equals(44.95));
+      expect(updatedObj.lastHistory, equals(NOW));
+    });
 
-  test('TemperatureFan partialUpdate - temperature', () {
-    TemperatureFan old = temperatureFanObjectWithRpm();
+    test('temperature', () {
+      TemperatureFan old = temperatureFanObjectWithRpm();
 
-    var updateJson = {"temperature": 99};
+      var updateJson = {"temperature": 99};
 
-    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+      var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.speed, equals(0.55));
-    expect(updatedObj.rpm, equals(500));
-    expect(updatedObj.temperature, equals(99));
-    expect(updatedObj.target, equals(44.95));
-    expect(updatedObj.lastHistory, equals(NOW));
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.speed, equals(0.55));
+      expect(updatedObj.rpm, equals(500));
+      expect(updatedObj.temperature, equals(99));
+      expect(updatedObj.target, equals(44.95));
+      expect(updatedObj.lastHistory, equals(NOW));
+    });
 
-  test('TemperatureFan partialUpdate - target', () {
-    TemperatureFan old = temperatureFanObjectWithRpm();
+    test('target', () {
+      TemperatureFan old = temperatureFanObjectWithRpm();
 
-    var updateJson = {"target": 85.22};
+      var updateJson = {"target": 85.22};
 
-    var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
+      var updatedObj = TemperatureFan.partialUpdate(old, updateJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.speed, equals(0.55));
-    expect(updatedObj.rpm, equals(500));
-    expect(updatedObj.temperature, equals(11.1));
-    expect(updatedObj.target, equals(85.22));
-    expect(updatedObj.lastHistory, equals(NOW));
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.speed, equals(0.55));
+      expect(updatedObj.rpm, equals(500));
+      expect(updatedObj.temperature, equals(11.1));
+      expect(updatedObj.target, equals(85.22));
+      expect(updatedObj.lastHistory, equals(NOW));
+    });
   });
 }
 

--- a/test/unit/marshalling/printer/temperature_sensor_marshalling_test.dart
+++ b/test/unit/marshalling/printer/temperature_sensor_marshalling_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/temperature_sensor.dart';
+
+import '../../../test_utils.dart';
+
+var NOW = DateTime.now();
+
+void main() {
+  test('TemperatureSensor fromJson', () {
+    var obj = temperatureSensorObject();
+
+    expect(obj, isNotNull);
+    expect(obj.temperature, equals(42.39));
+    expect(obj.measuredMinTemp, equals(39.7));
+    expect(obj.measuredMaxTemp, equals(60.69));
+    expect(obj.lastHistory, equals(NOW));
+    expect(obj.temperatureHistory, isNull);
+  });
+
+  test('TemperatureSensor partialUpdate - temperature', () {
+    var old = temperatureSensorObject();
+
+    var parsedJson = {
+      "temperature": 224.5,
+    };
+
+    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.temperature, equals(224.5));
+    expect(updatedObj.measuredMinTemp, equals(39.7));
+    expect(updatedObj.measuredMaxTemp, equals(60.69));
+    expect(updatedObj.lastHistory, equals(NOW));
+    expect(updatedObj.temperatureHistory, isNull);
+  });
+
+  test('TemperatureSensor partialUpdate - measured_min_temp', () {
+    var old = temperatureSensorObject();
+
+    var parsedJson = {
+      "measured_min_temp": 5.22,
+    };
+
+    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.temperature, equals(42.39));
+    expect(updatedObj.measuredMinTemp, equals(5.22));
+    expect(updatedObj.measuredMaxTemp, equals(60.69));
+    expect(updatedObj.lastHistory, equals(NOW));
+    expect(updatedObj.temperatureHistory, isNull);
+  });
+
+  test('TemperatureSensor partialUpdate - measured_max_temp', () {
+    var old = temperatureSensorObject();
+
+    var parsedJson = {
+      "measured_max_temp": 102.49,
+    };
+
+    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.temperature, equals(42.39));
+    expect(updatedObj.measuredMinTemp, equals(39.7));
+    expect(updatedObj.measuredMaxTemp, equals(102.49));
+    expect(updatedObj.lastHistory, equals(NOW));
+    expect(updatedObj.temperatureHistory, isNull);
+  });
+
+  test('TemperatureSensor partialUpdate - temperatureHistory', () {
+    var old = temperatureSensorObject();
+
+    var parsedJson = {
+      "temperatures": [30, 30, 31, 31, 32.5, 44, 45, 45, 9],
+    };
+
+    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+
+    expect(updatedObj, isNotNull);
+    expect(updatedObj.temperature, equals(42.39));
+    expect(updatedObj.measuredMinTemp, equals(39.7));
+    expect(updatedObj.measuredMaxTemp, equals(60.69));
+    expect(updatedObj.lastHistory, equals(NOW));
+    expect(updatedObj.temperatureHistory,
+        orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
+  });
+}
+
+TemperatureSensor temperatureSensorObject() {
+  String input =
+      '{"result": {"status": {"temperature_sensor raspberry_pi": {"measured_min_temp": 39.7, "measured_max_temp": 60.69, "temperature": 42.39}}, "eventtime": 4231105.430276898}}';
+
+  var parsedJson =
+      objectFromHttpApiResult(input, "temperature_sensor raspberry_pi");
+
+  return TemperatureSensor.fromJson(
+      {...parsedJson, "lastHistory": NOW.toIso8601String()}, "raspberry_pi");
+}

--- a/test/unit/marshalling/printer/temperature_sensor_marshalling_test.dart
+++ b/test/unit/marshalling/printer/temperature_sensor_marshalling_test.dart
@@ -17,73 +17,75 @@ void main() {
     expect(obj.temperatureHistory, isNull);
   });
 
-  test('TemperatureSensor partialUpdate - temperature', () {
-    var old = temperatureSensorObject();
+  group('TemperatureSensor partialUpdate', () {
+    test('temperature', () {
+      var old = temperatureSensorObject();
 
-    var parsedJson = {
-      "temperature": 224.5,
-    };
+      var parsedJson = {
+        "temperature": 224.5,
+      };
 
-    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+      var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.temperature, equals(224.5));
-    expect(updatedObj.measuredMinTemp, equals(39.7));
-    expect(updatedObj.measuredMaxTemp, equals(60.69));
-    expect(updatedObj.lastHistory, equals(NOW));
-    expect(updatedObj.temperatureHistory, isNull);
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.temperature, equals(224.5));
+      expect(updatedObj.measuredMinTemp, equals(39.7));
+      expect(updatedObj.measuredMaxTemp, equals(60.69));
+      expect(updatedObj.lastHistory, equals(NOW));
+      expect(updatedObj.temperatureHistory, isNull);
+    });
 
-  test('TemperatureSensor partialUpdate - measured_min_temp', () {
-    var old = temperatureSensorObject();
+    test('measured_min_temp', () {
+      var old = temperatureSensorObject();
 
-    var parsedJson = {
-      "measured_min_temp": 5.22,
-    };
+      var parsedJson = {
+        "measured_min_temp": 5.22,
+      };
 
-    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+      var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.temperature, equals(42.39));
-    expect(updatedObj.measuredMinTemp, equals(5.22));
-    expect(updatedObj.measuredMaxTemp, equals(60.69));
-    expect(updatedObj.lastHistory, equals(NOW));
-    expect(updatedObj.temperatureHistory, isNull);
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.temperature, equals(42.39));
+      expect(updatedObj.measuredMinTemp, equals(5.22));
+      expect(updatedObj.measuredMaxTemp, equals(60.69));
+      expect(updatedObj.lastHistory, equals(NOW));
+      expect(updatedObj.temperatureHistory, isNull);
+    });
 
-  test('TemperatureSensor partialUpdate - measured_max_temp', () {
-    var old = temperatureSensorObject();
+    test('measured_max_temp', () {
+      var old = temperatureSensorObject();
 
-    var parsedJson = {
-      "measured_max_temp": 102.49,
-    };
+      var parsedJson = {
+        "measured_max_temp": 102.49,
+      };
 
-    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+      var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.temperature, equals(42.39));
-    expect(updatedObj.measuredMinTemp, equals(39.7));
-    expect(updatedObj.measuredMaxTemp, equals(102.49));
-    expect(updatedObj.lastHistory, equals(NOW));
-    expect(updatedObj.temperatureHistory, isNull);
-  });
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.temperature, equals(42.39));
+      expect(updatedObj.measuredMinTemp, equals(39.7));
+      expect(updatedObj.measuredMaxTemp, equals(102.49));
+      expect(updatedObj.lastHistory, equals(NOW));
+      expect(updatedObj.temperatureHistory, isNull);
+    });
 
-  test('TemperatureSensor partialUpdate - temperatureHistory', () {
-    var old = temperatureSensorObject();
+    test('temperatureHistory', () {
+      var old = temperatureSensorObject();
 
-    var parsedJson = {
-      "temperatures": [30, 30, 31, 31, 32.5, 44, 45, 45, 9],
-    };
+      var parsedJson = {
+        "temperatures": [30, 30, 31, 31, 32.5, 44, 45, 45, 9],
+      };
 
-    var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
+      var updatedObj = TemperatureSensor.partialUpdate(old, parsedJson);
 
-    expect(updatedObj, isNotNull);
-    expect(updatedObj.temperature, equals(42.39));
-    expect(updatedObj.measuredMinTemp, equals(39.7));
-    expect(updatedObj.measuredMaxTemp, equals(60.69));
-    expect(updatedObj.lastHistory, equals(NOW));
-    expect(updatedObj.temperatureHistory,
-        orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.temperature, equals(42.39));
+      expect(updatedObj.measuredMinTemp, equals(39.7));
+      expect(updatedObj.measuredMaxTemp, equals(60.69));
+      expect(updatedObj.lastHistory, equals(NOW));
+      expect(updatedObj.temperatureHistory,
+          orderedEquals([30, 30, 31, 31, 32.5, 44, 45, 45, 9]));
+    });
   });
 }
 

--- a/test/unit/marshalling/printer/virtual_sd_card_marshalling_test.dart
+++ b/test/unit/marshalling/printer/virtual_sd_card_marshalling_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobileraker/data/dto/machine/virtual_sd_card.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  test('VirtualSdCard fromJson', () {
+    var obj = virtualSdCardObject();
+
+    expect(obj, isNotNull);
+    expect(obj.progress, equals(0.5));
+    expect(obj.isActive, equals(false));
+    expect(obj.filePosition, equals(40000));
+  });
+
+  group('VirtualSdCard partialUpdate', () {
+    test('progress', () {
+      var old = virtualSdCardObject();
+
+      var updateJson = {"progress": 0.44};
+
+      var updatedObj = VirtualSdCard.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.44));
+      expect(updatedObj.isActive, equals(false));
+      expect(updatedObj.filePosition, equals(40000));
+    });
+
+    test('is_active', () {
+      var old = virtualSdCardObject();
+
+      var updateJson = {"is_active": true};
+
+      var updatedObj = VirtualSdCard.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.5));
+      expect(updatedObj.isActive, equals(true));
+      expect(updatedObj.filePosition, equals(40000));
+    });
+
+    test('file_position', () {
+      var old = virtualSdCardObject();
+
+      var updateJson = {"file_position": 4242424};
+
+      var updatedObj = VirtualSdCard.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.5));
+      expect(updatedObj.isActive, equals(false));
+      expect(updatedObj.filePosition, equals(4242424));
+    });
+
+    test('Full update', () {
+      VirtualSdCard old = virtualSdCardObject();
+      String input =
+          '{"result": {"status": {"virtual_sdcard": {"progress": 0.25, "file_position": 20000, "is_active": true, "file_path": null, "file_size": 0}}, "eventtime": 3797749.173401586}}';
+
+      var updateJson = objectFromHttpApiResult(input, "virtual_sdcard");
+
+      var updatedObj = VirtualSdCard.partialUpdate(old, updateJson);
+
+      expect(updatedObj, isNotNull);
+      expect(updatedObj.progress, equals(0.25));
+      expect(updatedObj.isActive, equals(true));
+      expect(updatedObj.filePosition, equals(20000));
+    });
+  });
+}
+
+VirtualSdCard virtualSdCardObject() {
+  String input =
+      '{"result": {"status": {"virtual_sdcard": {"progress": 0.5, "file_position": 40000, "is_active": false, "file_path": null, "file_size": 0}}, "eventtime": 3797749.173401586}}';
+
+  var jsonRaw = objectFromHttpApiResult(input, "virtual_sdcard");
+
+  return VirtualSdCard.fromJson(jsonRaw);
+}


### PR DESCRIPTION
This is a POC to see if using the `*.fromJson` methods of JsonSerializable generated freezed classes to update the printer objects partially.

The advantage of this approach is:
1.  that we use the type-safe/correct parsing implementation of JsonSerializable
2. Move data code out of the service layer

If there are any other Dev who have a better idea about implementing the partial object updates please comment on this PR, I am just experimenting with this approach, which will create a TON of overhead for the processing of ´OldObject -> Json -> oldJson+newJson -> NewObject.FromJson´