### PR TITLE
fix: self signed certificate

### DIFF
--- a/lib/data/data_source/json_rpc_client.dart
+++ b/lib/data/data_source/json_rpc_client.dart
@@ -266,7 +266,7 @@ class JsonRpcClient {
     if (trustSelfSignedCertificate) {
       // only allow self signed certificates!
       httpClient.badCertificateCallback =
-          (cert, host, port) => cert.issuer == cert.subject;
+          (cert, host, port) => true;
     }
     return httpClient;
   }


### PR DESCRIPTION
While adding up my printer to the app, I got the same error as seen in this [issue](https://github.com/Clon1998/mobileraker/issues/73).
By changing the callback function that decides how to handle a bad certificate to to always return true, I can add my printer just fine.

Edit: tested only on my android device, but I guess (and hope!) it will work just fine on iOS