### PR TITLE
fix: correct 'occured' to 'occurred' typo in user-facing error messages

### DIFF
--- a/lib/app_setup.dart
+++ b/lib/app_setup.dart
@@ -216,7 +216,7 @@ Future<List<Box>> openBoxes([int tryNo = 1]) async {
         canResetStorage: true,
       );
     } else if (e is FileSystemException) {
-      talker.error('An FileSystemException(${e.runtimeType}) occured while trying to open Boxes (tryNo#$tryNo)...', e);
+      talker.error('An FileSystemException(${e.runtimeType}) occurred while trying to open Boxes (tryNo#$tryNo)...', e);
       if (tryNo < 4) {
         talker.error('Will retry to open boxes in 5 seconds');
         await Future.delayed(Duration(milliseconds: 400 * tryNo));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -152,9 +152,9 @@ class MyApp extends ConsumerWidget {
       errorWidget: (e) {
         return MaterialApp(
           home: ErrorCard(
-            title: const Text('Can not load languange files!'),
+            title: const Text('Can not load language files!'),
             body: Text(
-              'I am sorry. An unexpected error occured while loading the languange files.\nPlease submit this error to the developer via github: www.github.com/Clon1998/mobileraker\n\n\Error:\n$e',
+              'I am sorry. An unexpected error occurred while loading the language files.\nPlease submit this error to the developer via github: www.github.com/Clon1998/mobileraker\n\n\Error:\n$e',
             ),
           ),
         );

--- a/lib/ui/components/bottomsheet/user_bottom_sheet.dart
+++ b/lib/ui/components/bottomsheet/user_bottom_sheet.dart
@@ -64,7 +64,7 @@ class _CardBody extends ConsumerWidget {
       AsyncError() => const ErrorCard(
           title: Text('Error loading User management'),
           body: Text(
-            'An unexpected error occured while loading the User management. Please try again later.',
+            'An unexpected error occurred while loading the User management. Please try again later.',
           ),
         ),
       AsyncValue(hasValue: true, value: fba.User(isAnonymous: false)) => const _Profile(key: Key('profile')),
@@ -549,7 +549,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     } catch (e) {
       talker.error('Error signing in', e);
       state = state.whenData((value) =>
-          value.copyWith(errorText: 'An unexpected error occured while signing in. Please try again later.'));
+          value.copyWith(errorText: 'An unexpected error occurred while signing in. Please try again later.'));
     }
   }
 
@@ -571,7 +571,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     } catch (e) {
       talker.error('Unexpected error while trying to Sign-Up', e);
       state = state.whenData((value) =>
-          value.copyWith(errorText: 'An unexpected error occured while registering. Please try again later.'));
+          value.copyWith(errorText: 'An unexpected error occurred while registering. Please try again later.'));
     }
   }
 
@@ -580,7 +580,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     return _auth.signOut().catchError((e) {
       talker.error('Error signing out', e);
       state = state.whenData((value) =>
-          value.copyWith(errorText: 'An unexpected error occured while signing out. Please try again later.'));
+          value.copyWith(errorText: 'An unexpected error occurred while signing out. Please try again later.'));
     });
   }
 
@@ -593,7 +593,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     } catch (e) {
       talker.error('Error sending email verification', e);
       state = state.whenData((value) => value.copyWith(
-          errorText: 'An unexpected error occured while sending the email verification. Please try again later.'));
+          errorText: 'An unexpected error occurred while sending the email verification. Please try again later.'));
     }
   }
 
@@ -608,7 +608,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     } catch (e) {
       talker.error('Error sending password reset email', e);
       state = state.whenData((value) => value.copyWith(
-          errorText: 'An unexpected error occured while sending the password reset email. Please try again later.'));
+          errorText: 'An unexpected error occurred while sending the password reset email. Please try again later.'));
     }
   }
 
@@ -629,7 +629,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
     } catch (e) {
       talker.error('Error deleting user account', e);
       state = state.whenData((value) => value.copyWith(
-            errorText: 'An unexpected error occured while deleting your account. Please try again later.',
+            errorText: 'An unexpected error occurred while deleting your account. Please try again later.',
           ));
     }
   }
@@ -639,7 +639,7 @@ class _UserBottomSheetController extends _$UserBottomSheetController {
       var errorCode = PurchasesErrorHelper.getErrorCode(e);
       talker.error('Error restoring purchases. Error code: $errorCode');
       state = state.whenData(
-        (value) => value.copyWith(errorText: 'An unexpected error occured while restoring purchases.\n$errorCode'),
+        (value) => value.copyWith(errorText: 'An unexpected error occurred while restoring purchases.\n$errorCode'),
       );
     });
     _showInfoText(tr('bottom_sheets.profile.restore_success'));


### PR DESCRIPTION
## Summary
Correct spelling error in 3 Dart files - all user-facing error messages displayed in the Flutter mobile app.

## Changes
- `lib/main.dart`: 'occured'→'occurred' and 'languange'→'language' in error widget
- `lib/app_setup.dart`: 'occured'→'occurred' in FileSystemException error handler  
- `lib/ui/components/bottomsheet/user_bottom_sheet.dart`: 'occured'→'occurred' in 8 user-facing error messages (sign in, register, sign out, email verification, password reset, delete account, restore purchases, user management)

## Why
All instances are user-facing error messages shown in the mobile app UI. Misspelling 'occurred' undermines the professional tone of error notifications.

Signed-off-by: Jah-yee <jydu_seven@outlook.com>